### PR TITLE
WIP: add trusted custom plugin harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ desktop.ini
 # ============================================
 .claude/
 .playwright-mcp/
+TODO.md
+PLAN.md

--- a/deno.json
+++ b/deno.json
@@ -3,11 +3,12 @@
     "./packages/psycheros",
     "./packages/entity-core",
     "./packages/entity-loom",
-    "./packages/launcher"
+    "./packages/launcher",
+    "./packages/plugin-api"
   ],
   "nodeModulesDir": "auto",
   "tasks": {
-    "test": "deno test -A packages/psycheros/tests/ packages/entity-core/tests/",
+    "test": "deno test -A packages/psycheros/tests/ packages/entity-core/tests/ packages/plugin-api/tests/",
     "fmt": "deno fmt",
     "fmt:check": "deno fmt --check"
   },

--- a/packages/entity-core/CLAUDE.md
+++ b/packages/entity-core/CLAUDE.md
@@ -36,6 +36,15 @@ full schemas are in [`docs/mcp-tools.md`](docs/mcp-tools.md).
 2. Register it in `src/tools/mod.ts`.
 3. Write the description in first person ("I use this to…").
 
+## Trusted local plugins
+
+Entity-core loads optional plugin entrypoints from `PSYCHEROS_PLUGIN_DIR` before
+MCP connects. The manager in `src/plugins/` registers additional MCP tools and
+additive result decorators. Decorators run after core handlers and cannot
+overwrite core fields. My plugin-owned credentials live beside the shared plugin
+directory under `.psycheros/plugin-secrets/<id>.env`. I apply them before import
+and keep them out of portable entity exports.
+
 ## Storage layout
 
 All persistent state lives in `data/`:

--- a/packages/entity-core/src/plugins/mod.ts
+++ b/packages/entity-core/src/plugins/mod.ts
@@ -1,0 +1,4 @@
+export {
+  createEntityCorePluginManager,
+  EntityCorePluginManager,
+} from "./plugin-manager.ts";

--- a/packages/entity-core/src/plugins/plugin-manager.ts
+++ b/packages/entity-core/src/plugins/plugin-manager.ts
@@ -1,0 +1,276 @@
+/**
+ * Trusted local plugin harness for my canonical core.
+ */
+
+import { join, toFileUrl } from "@std/path";
+import {
+  type AppliedPluginEnv,
+  applyPluginEnv,
+  emptyPluginCapabilityCounts,
+  type PluginEnv,
+  type PluginManifest,
+  type PluginStatus,
+  validatePluginManifest,
+  validatePluginRelativePath,
+} from "../../../plugin-api/src/mod.ts";
+import type { FileStore } from "../storage/mod.ts";
+import type { GraphStore } from "../graph/mod.ts";
+import type { EmbeddingCache } from "../embeddings/mod.ts";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { z } from "zod";
+
+export interface EntityCorePluginServices {
+  dataDir: string;
+  statePath: string;
+  env: PluginEnv;
+  store: FileStore;
+  graphStore: GraphStore;
+  embeddingCache: EmbeddingCache;
+  log: (...args: unknown[]) => void;
+}
+
+export interface EntityCorePluginTool {
+  name: string;
+  description: string;
+  schema: Record<string, z.ZodTypeAny>;
+  handler: (
+    args: Record<string, unknown>,
+    services: EntityCorePluginServices,
+  ) => unknown | Promise<unknown>;
+}
+
+export interface EntityCoreResultDecorator {
+  tool: string;
+  name: string;
+  priority?: number;
+  decorate: (
+    result: Record<string, unknown>,
+    services: EntityCorePluginServices,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
+}
+
+interface EntityCorePluginModule {
+  tools?: EntityCorePluginTool[];
+  resultDecorators?: EntityCoreResultDecorator[];
+  start?: (services: EntityCorePluginServices) => void | Promise<void>;
+  stop?: (services: EntityCorePluginServices) => void | Promise<void>;
+}
+
+interface LoadedPlugin {
+  directory: string;
+  manifest: PluginManifest;
+  module?: EntityCorePluginModule;
+  appliedEnv?: AppliedPluginEnv;
+  status: PluginStatus;
+}
+
+function safeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class EntityCorePluginManager {
+  private plugins: LoadedPlugin[] = [];
+
+  constructor(
+    private pluginRoot: string,
+    private baseServices: Omit<EntityCorePluginServices, "statePath" | "env">,
+  ) {}
+
+  private services(plugin: LoadedPlugin): EntityCorePluginServices {
+    return {
+      ...this.baseServices,
+      statePath: join(plugin.directory, "state"),
+      env: plugin.appliedEnv?.env ?? {
+        get: (name) => Deno.env.get(name),
+        has: (name) => Deno.env.has(name),
+        require(name) {
+          const value = Deno.env.get(name);
+          if (!value) {
+            throw new Error(`missing required plugin environment: ${name}`);
+          }
+          return value;
+        },
+      },
+    };
+  }
+
+  async load(): Promise<void> {
+    await this.stop();
+    this.plugins = [];
+    let entries: Deno.DirEntry[];
+    try {
+      entries = Array.from(Deno.readDirSync(this.pluginRoot));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return;
+      throw error;
+    }
+    for (const entry of entries.filter((item) => item.isDirectory)) {
+      const directory = join(this.pluginRoot, entry.name);
+      let appliedEnv: AppliedPluginEnv | undefined;
+      try {
+        const manifest = validatePluginManifest(
+          JSON.parse(await Deno.readTextFile(join(directory, "plugin.json"))),
+          entry.name,
+        );
+        const status: PluginStatus = {
+          id: manifest.id,
+          name: manifest.name,
+          version: manifest.version,
+          enabled: manifest.enabled,
+          active: false,
+          degraded: false,
+          restartRequired: false,
+          entrypoints: {
+            psycheros: !!manifest.entrypoints?.psycheros,
+            entityCore: !!manifest.entrypoints?.entityCore,
+          },
+          capabilities: emptyPluginCapabilityCounts(),
+        };
+        const loaded: LoadedPlugin = { directory, manifest, status };
+        this.plugins.push(loaded);
+        if (!manifest.enabled || !manifest.entrypoints?.entityCore) continue;
+        appliedEnv = await applyPluginEnv(this.pluginRoot, manifest.id);
+        loaded.appliedEnv = appliedEnv;
+        const entrypoint = validatePluginRelativePath(
+          manifest.entrypoints.entityCore,
+        );
+        const imported = await import(
+          toFileUrl(join(directory, entrypoint)).href
+        );
+        loaded.module =
+          (imported.default ?? imported) as EntityCorePluginModule;
+        status.capabilities.tools = loaded.module.tools?.length ?? 0;
+        status.capabilities.resultDecorators =
+          loaded.module.resultDecorators?.length ?? 0;
+        status.active = true;
+        await loaded.module.start?.(this.services(loaded));
+      } catch (error) {
+        appliedEnv?.restore();
+        console.error(`[Plugins] Failed to load ${entry.name}:`, error);
+        this.plugins = this.plugins.filter((plugin) =>
+          plugin.manifest.id !== entry.name
+        );
+        this.plugins.push({
+          directory,
+          manifest: {
+            id: entry.name,
+            name: entry.name,
+            version: "unknown",
+            apiVersion: 1,
+            enabled: false,
+          },
+          status: {
+            id: entry.name,
+            name: entry.name,
+            version: "unknown",
+            enabled: false,
+            active: false,
+            degraded: true,
+            restartRequired: false,
+            entrypoints: { psycheros: false, entityCore: false },
+            capabilities: emptyPluginCapabilityCounts(),
+            lastError: safeError(error),
+          },
+        });
+      }
+    }
+    this.plugins.sort((a, b) => a.manifest.id.localeCompare(b.manifest.id));
+  }
+
+  async stop(): Promise<void> {
+    for (const plugin of [...this.plugins].reverse()) {
+      try {
+        await plugin.module?.stop?.(this.services(plugin));
+      } catch (error) {
+        console.error(`[Plugins] Failed to stop ${plugin.manifest.id}:`, error);
+      } finally {
+        plugin.appliedEnv?.restore();
+        plugin.appliedEnv = undefined;
+      }
+    }
+  }
+
+  getStatuses(): PluginStatus[] {
+    return this.plugins.map((plugin) => ({ ...plugin.status }));
+  }
+
+  getTools(): Array<{
+    plugin: LoadedPlugin;
+    tool: EntityCorePluginTool;
+  }> {
+    return this.plugins.flatMap((plugin) =>
+      (plugin.module?.tools ?? []).map((tool) => ({ plugin, tool }))
+    );
+  }
+
+  async decorate(
+    toolName: string,
+    input: unknown,
+  ): Promise<Record<string, unknown>> {
+    const result: Record<string, unknown> =
+      input && typeof input === "object" && !Array.isArray(input)
+        ? { ...input as Record<string, unknown> }
+        : { result: input };
+    const failures: Array<{ plugin: string; decorator: string }> = [];
+    const decorators = this.plugins.flatMap((plugin) =>
+      (plugin.module?.resultDecorators ?? [])
+        .filter((decorator) => decorator.tool === toolName)
+        .map((decorator) => ({ plugin, decorator }))
+    ).sort((a, b) =>
+      (a.decorator.priority ?? 0) - (b.decorator.priority ?? 0) ||
+      a.plugin.manifest.id.localeCompare(b.plugin.manifest.id) ||
+      a.decorator.name.localeCompare(b.decorator.name)
+    );
+
+    for (const { plugin, decorator } of decorators) {
+      try {
+        const addition = await decorator.decorate(
+          { ...result },
+          this.services(plugin),
+        );
+        for (const [key, value] of Object.entries(addition)) {
+          if (key in result) throw new Error(`field collision: ${key}`);
+          result[key] = value;
+        }
+      } catch (error) {
+        plugin.status.degraded = true;
+        plugin.status.lastError = safeError(error);
+        failures.push({
+          plugin: plugin.manifest.id,
+          decorator: decorator.name,
+        });
+        console.error(
+          `[Plugins] Decorator ${plugin.manifest.id}/${decorator.name} failed:`,
+          error,
+        );
+      }
+    }
+    if (failures.length > 0) result.plugin_failures = failures;
+    return result;
+  }
+
+  registerTools(server: McpServer): void {
+    for (const { plugin, tool } of this.getTools()) {
+      server.tool(tool.name, tool.description, tool.schema, async (args) => ({
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(
+            await this.decorate(
+              tool.name,
+              await tool.handler(args, this.services(plugin)),
+            ),
+            null,
+            2,
+          ),
+        }],
+      }));
+    }
+  }
+}
+
+export function createEntityCorePluginManager(
+  pluginRoot: string,
+  services: Omit<EntityCorePluginServices, "statePath" | "env">,
+): EntityCorePluginManager {
+  return new EntityCorePluginManager(pluginRoot, services);
+}

--- a/packages/entity-core/src/server.ts
+++ b/packages/entity-core/src/server.ts
@@ -66,6 +66,10 @@ import type { ServerConfig } from "./types.ts";
 import { DEFAULT_SERVER_CONFIG } from "./types.ts";
 import { cleanupOldSnapshots } from "./snapshot/mod.ts";
 import { EmbeddingCache } from "./embeddings/mod.ts";
+import {
+  createEntityCorePluginManager,
+  type EntityCorePluginManager,
+} from "./plugins/mod.ts";
 
 /**
  * Create and configure the MCP server.
@@ -83,6 +87,7 @@ export function createServer(config: Partial<ServerConfig> = {}): McpServer {
 
   // Initialize embedding cache (shares graph.db for sqlite-vec)
   const embeddingCache = new EmbeddingCache(fullConfig.dataDir);
+  const pluginManager = fullConfig.pluginManager;
 
   // Create MCP server
   const server = new McpServer({
@@ -103,7 +108,13 @@ export function createServer(config: Partial<ServerConfig> = {}): McpServer {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(
+              pluginManager
+                ? await pluginManager.decorate("identity_get_all", result)
+                : result,
+              null,
+              2,
+            ),
           },
         ],
       };
@@ -127,7 +138,13 @@ export function createServer(config: Partial<ServerConfig> = {}): McpServer {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(
+              pluginManager
+                ? await pluginManager.decorate("identity_write", result)
+                : result,
+              null,
+              2,
+            ),
           },
         ],
       };
@@ -151,7 +168,13 @@ export function createServer(config: Partial<ServerConfig> = {}): McpServer {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(
+              pluginManager
+                ? await pluginManager.decorate("identity_append", result)
+                : result,
+              null,
+              2,
+            ),
           },
         ],
       };
@@ -441,7 +464,13 @@ export function createServer(config: Partial<ServerConfig> = {}): McpServer {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(
+              pluginManager
+                ? await pluginManager.decorate("memory_search", result)
+                : result,
+              null,
+              2,
+            ),
           },
         ],
       };
@@ -1330,6 +1359,20 @@ export function createServer(config: Partial<ServerConfig> = {}): McpServer {
     },
   );
 
+  server.tool(
+    "plugin_status",
+    "I use this to inspect the trusted local extensions available to my core.",
+    {},
+    () => ({
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify(pluginManager?.getStatuses() ?? [], null, 2),
+      }],
+    }),
+  );
+
+  pluginManager?.registerTools(server);
+
   return server;
 }
 
@@ -1339,14 +1382,38 @@ export function createServer(config: Partial<ServerConfig> = {}): McpServer {
 export async function startServer(
   config: Partial<ServerConfig> = {},
 ): Promise<void> {
-  const server = createServer(config);
-  const transport = new StdioServerTransport();
-
   // Auto-rebuild embeddings if schema version changed (e.g., date enrichment
   // added). This runs before connecting so the entity-core process handles it
   // on startup rather than silently serving stale vectors.
   const fullConfig: ServerConfig = { ...DEFAULT_SERVER_CONFIG, ...config };
   await autoRebuildEmbeddings(fullConfig.dataDir);
+
+  let pluginManager: EntityCorePluginManager | undefined =
+    fullConfig.pluginManager;
+  if (!pluginManager) {
+    const store = fullConfig.store ?? new FileStore(fullConfig.dataDir);
+    const graphStore = fullConfig.graphStore ??
+      new GraphStore(fullConfig.dataDir);
+    const embeddingCache = new EmbeddingCache(fullConfig.dataDir);
+    pluginManager = createEntityCorePluginManager(
+      Deno.env.get("PSYCHEROS_PLUGIN_DIR") ??
+        `${fullConfig.dataDir}/../.psycheros/plugins`,
+      {
+        dataDir: fullConfig.dataDir,
+        store,
+        graphStore,
+        embeddingCache,
+        log: (...args) => console.error("[Plugins]", ...args),
+      },
+    );
+    await pluginManager.load();
+  }
+
+  const server = createServer({ ...config, pluginManager });
+  const transport = new StdioServerTransport();
+  transport.onclose = () => {
+    void pluginManager?.stop();
+  };
 
   await server.connect(transport);
 

--- a/packages/entity-core/src/types.ts
+++ b/packages/entity-core/src/types.ts
@@ -221,6 +221,8 @@ export interface ServerConfig {
    * keep using a stale (closed) connection.
    */
   consolidationRunner?: import("./consolidation/runner.ts").ConsolidationRunner;
+  /** Trusted local plugins prepared before the MCP transport connects */
+  pluginManager?: import("./plugins/mod.ts").EntityCorePluginManager;
   /** Minimum score threshold for RAG retrieval */
   ragMinScore?: number;
   /** Maximum chunks to retrieve */

--- a/packages/launcher-v2/frontend/index.html
+++ b/packages/launcher-v2/frontend/index.html
@@ -956,8 +956,8 @@
             <strong>Back up</strong>
             <span class="data-action__detail">
               Exports a snapshot of my entity data (memories, vault, identity,
-              settings, generated images) as a zip in your Downloads folder.
-              Daemon must be running.
+              settings, generated images, and trusted local plugins) as a zip in
+              your Downloads folder. Daemon must be running.
             </span>
           </div>
           <button type="button" id="data-backup" class="primary">
@@ -971,7 +971,8 @@
             <span class="data-action__detail">
               Reads a previously-exported zip and replaces my current data with
               what's inside it. Daemon must be running; I'll restart
-              automatically when the import finishes.
+              automatically when the import finishes. Restored plugins are
+              executable local code and may contain secrets.
             </span>
           </div>
           <button type="button" id="data-restore">

--- a/packages/launcher-v2/src-tauri/src/commands.rs
+++ b/packages/launcher-v2/src-tauri/src/commands.rs
@@ -2493,8 +2493,10 @@ mod tests {
         // <launcher_dir>/data per the env override.
         let psy_dir = launcher_dir.path().join("data").join(".psycheros");
         std::fs::create_dir_all(psy_dir.join("vault/documents")).unwrap();
+        std::fs::create_dir_all(psy_dir.join("plugins/example/state")).unwrap();
         std::fs::write(psy_dir.join("settings.json"), br#"{"ok":true}"#).unwrap();
         std::fs::write(psy_dir.join("vault/documents/note.md"), b"hello").unwrap();
+        std::fs::write(psy_dir.join("plugins/example/state/cache.json"), b"{}").unwrap();
 
         let snapshot_id = create_pre_update_snapshot()
             .expect("snapshot should succeed against a populated data dir");
@@ -2513,6 +2515,10 @@ mod tests {
         assert_eq!(
             std::fs::read(snap_root.join("vault/documents/note.md")).unwrap(),
             b"hello"
+        );
+        assert_eq!(
+            std::fs::read(snap_root.join("plugins/example/state/cache.json")).unwrap(),
+            b"{}"
         );
     }
 

--- a/packages/plugin-api/README.md
+++ b/packages/plugin-api/README.md
@@ -1,0 +1,13 @@
+# Psycheros Plugin API
+
+Shared structural types and validation for trusted local plugins. The authoring
+guide lives at [`../psycheros/docs/plugins.md`](../psycheros/docs/plugins.md).
+
+I can import `@psycheros/plugin-api/testing` for isolated fixture directories
+with sibling `plugins/` and `plugin-secrets/` trees.
+
+From the workspace root, validate a manual installation with:
+
+```powershell
+deno task --cwd packages/plugin-api validate <plugin-directory>
+```

--- a/packages/plugin-api/deno.json
+++ b/packages/plugin-api/deno.json
@@ -1,0 +1,12 @@
+{
+  "name": "@psycheros/plugin-api",
+  "version": "0.1.0",
+  "exports": {
+    ".": "./src/mod.ts",
+    "./testing": "./src/testing.ts"
+  },
+  "tasks": {
+    "test": "deno test -A tests/",
+    "validate": "deno run --allow-read scripts/validate-plugin.ts"
+  }
+}

--- a/packages/plugin-api/scripts/validate-plugin.ts
+++ b/packages/plugin-api/scripts/validate-plugin.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env -S deno run --allow-read
+
+import { resolve } from "@std/path";
+import { validatePluginDirectory } from "../src/mod.ts";
+
+const directory = Deno.args[0];
+if (!directory) {
+  console.error(
+    "Usage: deno run --allow-read scripts/validate-plugin.ts <plugin-directory>",
+  );
+  Deno.exit(1);
+}
+
+try {
+  const manifest = await validatePluginDirectory(resolve(directory));
+  console.log(
+    `Validated ${manifest.name} (${manifest.id}) v${manifest.version} for plugin API ${manifest.apiVersion}.`,
+  );
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  Deno.exit(1);
+}

--- a/packages/plugin-api/src/mod.ts
+++ b/packages/plugin-api/src/mod.ts
@@ -1,0 +1,307 @@
+/**
+ * Shared plugin contract for my Psycheros hosts.
+ */
+
+import { basename, extname, isAbsolute, join, normalize } from "@std/path";
+import { parse } from "@std/dotenv";
+
+export const PLUGIN_API_VERSION = 1;
+export const DEFAULT_PROMPT_HOOK_TIMEOUT_MS = 15_000;
+export const DEFAULT_PROMPT_HOOK_MAX_CHARS = 12_000;
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  apiVersion: number;
+  enabled: boolean;
+  entrypoints?: {
+    psycheros?: string;
+    entityCore?: string;
+  };
+  browser?: {
+    scripts?: string[];
+    styles?: string[];
+  };
+  promptHookDefaults?: {
+    timeoutMs?: number;
+    maxChars?: number;
+  };
+}
+
+export interface PluginCapabilityCounts {
+  tools: number;
+  promptHooks: number;
+  routes: number;
+  resultDecorators: number;
+  browserScripts: number;
+  browserStyles: number;
+}
+
+export interface PluginStatus {
+  id: string;
+  name: string;
+  version: string;
+  enabled: boolean;
+  active: boolean;
+  degraded: boolean;
+  restartRequired: boolean;
+  entrypoints: {
+    psycheros: boolean;
+    entityCore: boolean;
+  };
+  capabilities: PluginCapabilityCounts;
+  lastError?: string;
+}
+
+export interface DiscoveredPlugin {
+  directory: string;
+  manifest: PluginManifest;
+}
+
+export interface PluginEnv {
+  get(name: string): string | undefined;
+  has(name: string): boolean;
+  require(name: string): string;
+}
+
+export interface AppliedPluginEnv {
+  env: PluginEnv;
+  restore(): void;
+}
+
+function requireString(
+  value: unknown,
+  field: string,
+): asserts value is string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+}
+
+export function isSafePluginId(id: string): boolean {
+  return /^[a-z0-9][a-z0-9._-]*$/.test(id);
+}
+
+/**
+ * Validate a path declared by a plugin manifest.
+ *
+ * Manifest paths are always relative to the plugin directory. Requiring a
+ * leading "./" makes that boundary visible to plugin authors and reviewers.
+ */
+export function validatePluginRelativePath(path: string): string {
+  requireString(path, "plugin path");
+  if (!path.startsWith("./") || isAbsolute(path)) {
+    throw new Error(`plugin path must start with "./": ${path}`);
+  }
+  const normalized = normalize(path.replace(/\\/g, "/")).replace(/\\/g, "/");
+  if (
+    normalized === ".." || normalized.startsWith("../") ||
+    normalized.includes("/../")
+  ) {
+    throw new Error(`plugin path escapes its directory: ${path}`);
+  }
+  return normalized.startsWith("./") ? normalized.slice(2) : normalized;
+}
+
+export function validatePluginManifest(
+  raw: unknown,
+  directoryName: string,
+): PluginManifest {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("plugin.json must contain an object");
+  }
+  const input = raw as Record<string, unknown>;
+  requireString(input.id, "id");
+  requireString(input.name, "name");
+  requireString(input.version, "version");
+  if (!isSafePluginId(input.id)) {
+    throw new Error(`id contains unsupported characters: ${input.id}`);
+  }
+  if (input.id !== directoryName) {
+    throw new Error(`id must match directory name "${directoryName}"`);
+  }
+  if (input.apiVersion !== PLUGIN_API_VERSION) {
+    throw new Error(`unsupported apiVersion: ${String(input.apiVersion)}`);
+  }
+
+  const entrypoints = input.entrypoints as
+    | Record<string, unknown>
+    | undefined;
+  const browser = input.browser as Record<string, unknown> | undefined;
+  const promptDefaults = input.promptHookDefaults as
+    | Record<string, unknown>
+    | undefined;
+  const validateOptionalPath = (value: unknown): string | undefined => {
+    if (value === undefined) return undefined;
+    return `./${validatePluginRelativePath(String(value))}`;
+  };
+  const validateOptionalEntrypoint = (value: unknown): string | undefined => {
+    const path = validateOptionalPath(value);
+    if (
+      path !== undefined && extname(path).toLowerCase() !== ".ts" &&
+      extname(path).toLowerCase() !== ".js"
+    ) {
+      throw new Error(`plugin entrypoint must use .ts or .js: ${path}`);
+    }
+    return path;
+  };
+  const validatePathArray = (value: unknown): string[] | undefined => {
+    if (value === undefined) return undefined;
+    if (!Array.isArray(value)) throw new Error("browser paths must be arrays");
+    return value.map((path) => `./${validatePluginRelativePath(String(path))}`);
+  };
+  const validatePositiveNumber = (
+    value: unknown,
+    field: string,
+  ): number | undefined => {
+    if (value === undefined) return undefined;
+    if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+      throw new Error(`${field} must be a positive number`);
+    }
+    return value;
+  };
+
+  return {
+    id: input.id,
+    name: input.name,
+    version: input.version,
+    apiVersion: input.apiVersion,
+    enabled: input.enabled === undefined ? true : input.enabled === true,
+    entrypoints: entrypoints
+      ? {
+        psycheros: validateOptionalEntrypoint(entrypoints.psycheros),
+        entityCore: validateOptionalEntrypoint(entrypoints.entityCore),
+      }
+      : undefined,
+    browser: browser
+      ? {
+        scripts: validatePathArray(browser.scripts),
+        styles: validatePathArray(browser.styles),
+      }
+      : undefined,
+    promptHookDefaults: promptDefaults
+      ? {
+        timeoutMs: validatePositiveNumber(
+          promptDefaults.timeoutMs,
+          "promptHookDefaults.timeoutMs",
+        ),
+        maxChars: validatePositiveNumber(
+          promptDefaults.maxChars,
+          "promptHookDefaults.maxChars",
+        ),
+      }
+      : undefined,
+  };
+}
+
+export function emptyPluginCapabilityCounts(): PluginCapabilityCounts {
+  return {
+    tools: 0,
+    promptHooks: 0,
+    routes: 0,
+    resultDecorators: 0,
+    browserScripts: 0,
+    browserStyles: 0,
+  };
+}
+
+/**
+ * Apply a plugin-owned environment file for the lifetime of one host load.
+ *
+ * My secrets live outside the executable plugin tree so my portable plugin
+ * backups do not include credentials. I should use namespaced variables
+ * because my trusted plugins share one process environment.
+ */
+export async function applyPluginEnv(
+  pluginRoot: string,
+  pluginId: string,
+): Promise<AppliedPluginEnv> {
+  const values = await readPluginEnv(pluginRoot, pluginId);
+  const previous = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(values)) {
+    previous.set(name, Deno.env.get(name));
+    Deno.env.set(name, value);
+  }
+
+  return {
+    env: createPluginEnv(),
+    restore() {
+      for (const [name, value] of previous) {
+        if (value === undefined) Deno.env.delete(name);
+        else Deno.env.set(name, value);
+      }
+    },
+  };
+}
+
+export function getPluginEnvPath(pluginRoot: string, pluginId: string): string {
+  if (!isSafePluginId(pluginId)) {
+    throw new Error(`invalid plugin id: ${pluginId}`);
+  }
+  return join(pluginRoot, "..", "plugin-secrets", `${pluginId}.env`);
+}
+
+export async function readPluginEnv(
+  pluginRoot: string,
+  pluginId: string,
+): Promise<Record<string, string>> {
+  try {
+    return parse(
+      await Deno.readTextFile(getPluginEnvPath(pluginRoot, pluginId)),
+    );
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return {};
+    throw error;
+  }
+}
+
+export function createPluginEnv(): PluginEnv {
+  return {
+    get: (name) => Deno.env.get(name),
+    has: (name) => Deno.env.has(name),
+    require(name) {
+      const value = Deno.env.get(name);
+      if (!value) {
+        throw new Error(`missing required plugin environment: ${name}`);
+      }
+      return value;
+    },
+  };
+}
+
+/**
+ * Identify conventional credential files that should never enter my portable
+ * plugin archives. My plugin state may still contain sensitive provider data,
+ * so I should keep credentials in the supported plugin-secrets directory.
+ */
+export function isPluginSecretFilename(path: string): boolean {
+  const name = path.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
+  return name === ".env" || name.endsWith(".env") ||
+    name === "secrets.json" || name === ".secrets.json";
+}
+
+/**
+ * Validate my manually installed plugin directory before my next restart.
+ */
+export async function validatePluginDirectory(
+  directory: string,
+): Promise<PluginManifest> {
+  const manifest = validatePluginManifest(
+    JSON.parse(await Deno.readTextFile(join(directory, "plugin.json"))),
+    basename(normalize(directory)),
+  );
+  const paths = [
+    manifest.entrypoints?.psycheros,
+    manifest.entrypoints?.entityCore,
+    ...(manifest.browser?.scripts ?? []),
+    ...(manifest.browser?.styles ?? []),
+  ].filter((path): path is string => path !== undefined);
+  for (const path of paths) {
+    const stat = await Deno.stat(
+      join(directory, validatePluginRelativePath(path)),
+    );
+    if (!stat.isFile) throw new Error(`plugin path is not a file: ${path}`);
+  }
+  return manifest;
+}

--- a/packages/plugin-api/src/testing.ts
+++ b/packages/plugin-api/src/testing.ts
@@ -1,0 +1,43 @@
+/**
+ * Helpers for exercising my trusted local plugins in Deno tests.
+ */
+
+import { join } from "@std/path";
+import type { PluginManifest } from "./mod.ts";
+
+export interface PluginFixture {
+  root: string;
+  directory: string;
+  secretsDirectory: string;
+}
+
+export async function createPluginFixture(
+  manifest: Omit<PluginManifest, "enabled"> & { enabled?: boolean },
+  files: Record<string, string>,
+  secrets?: Record<string, string>,
+): Promise<PluginFixture> {
+  const parent = await Deno.makeTempDir({ prefix: "psycheros-plugin-" });
+  const root = join(parent, "plugins");
+  const directory = join(root, manifest.id);
+  const secretsDirectory = join(parent, "plugin-secrets");
+  await Deno.mkdir(directory, { recursive: true });
+  await Deno.writeTextFile(
+    join(directory, "plugin.json"),
+    JSON.stringify(manifest, null, 2),
+  );
+  for (const [path, content] of Object.entries(files)) {
+    const destination = join(directory, ...path.split("/"));
+    await Deno.mkdir(join(destination, ".."), { recursive: true });
+    await Deno.writeTextFile(destination, content);
+  }
+  if (secrets && Object.keys(secrets).length > 0) {
+    await Deno.mkdir(secretsDirectory, { recursive: true });
+    await Deno.writeTextFile(
+      join(secretsDirectory, `${manifest.id}.env`),
+      Object.entries(secrets).map(([name, value]) => `${name}=${value}`).join(
+        "\n",
+      ),
+    );
+  }
+  return { root, directory, secretsDirectory };
+}

--- a/packages/plugin-api/tests/entity_core_manager_test.ts
+++ b/packages/plugin-api/tests/entity_core_manager_test.ts
@@ -1,0 +1,80 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import type { EmbeddingCache } from "../../entity-core/src/embeddings/mod.ts";
+import type { GraphStore } from "../../entity-core/src/graph/mod.ts";
+import { EntityCorePluginManager } from "../../entity-core/src/plugins/mod.ts";
+import type { FileStore } from "../../entity-core/src/storage/mod.ts";
+
+Deno.test("entity-core decorators add fields and preserve core fields on collision", async () => {
+  const root = await Deno.makeTempDir();
+  const directory = join(root, "rag-fields");
+  await Deno.mkdir(directory, { recursive: true });
+  await Deno.writeTextFile(
+    join(directory, "plugin.json"),
+    JSON.stringify({
+      id: "rag-fields",
+      name: "RAG Fields",
+      version: "1.0.0",
+      apiVersion: 1,
+      entrypoints: { entityCore: "./entity-core.ts" },
+    }),
+  );
+  await Deno.writeTextFile(
+    join(directory, "entity-core.ts"),
+    `export default { resultDecorators: [
+      { tool: "memory_search", name: "links", async decorate() { return { artifact_links: ["one"] }; } },
+      { tool: "memory_search", name: "collision", async decorate() { return { results: [] }; } },
+      { tool: "memory_search", name: "secret", async decorate(_result, services) { return { provider_key: services.env.require("PSYCHEROS_PLUGIN_RAG_API_KEY") }; } }
+    ],
+    tools: [{ name: "rag_status", description: "I use this to inspect my retrieval integration.", schema: {}, handler(_args, services) { return { configured: services.env.has("PSYCHEROS_PLUGIN_RAG_API_KEY") }; } }]
+    };`,
+  );
+  await Deno.mkdir(join(root, "..", "plugin-secrets"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "..", "plugin-secrets", "rag-fields.env"),
+    "PSYCHEROS_PLUGIN_RAG_API_KEY=provider-secret",
+  );
+
+  const fake = {} as unknown;
+  const manager = new EntityCorePluginManager(root, {
+    dataDir: root,
+    store: fake as FileStore,
+    graphStore: fake as GraphStore,
+    embeddingCache: fake as EmbeddingCache,
+    log: () => {},
+  });
+  await manager.load();
+  try {
+    const result = await manager.decorate("memory_search", {
+      results: ["core"],
+    });
+
+    assertEquals(result.results, ["core"]);
+    assertEquals(result.artifact_links, ["one"]);
+    assertEquals(result.provider_key, "provider-secret");
+    assertEquals(result.plugin_failures, [{
+      plugin: "rag-fields",
+      decorator: "collision",
+    }]);
+    const [{ plugin, tool }] = manager.getTools();
+    assertEquals(
+      await tool.handler({}, {
+        dataDir: root,
+        statePath: join(plugin.directory, "state"),
+        env: {
+          get: (name) => Deno.env.get(name),
+          has: (name) => Deno.env.has(name),
+          require: (name) => Deno.env.get(name) ?? "",
+        },
+        store: fake as FileStore,
+        graphStore: fake as GraphStore,
+        embeddingCache: fake as EmbeddingCache,
+        log: () => {},
+      }),
+      { configured: true },
+    );
+  } finally {
+    await manager.stop();
+  }
+  assertEquals(Deno.env.has("PSYCHEROS_PLUGIN_RAG_API_KEY"), false);
+});

--- a/packages/plugin-api/tests/manifest_test.ts
+++ b/packages/plugin-api/tests/manifest_test.ts
@@ -1,0 +1,130 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { join } from "@std/path";
+import {
+  applyPluginEnv,
+  getPluginEnvPath,
+  isPluginSecretFilename,
+  validatePluginDirectory,
+  validatePluginManifest,
+  validatePluginRelativePath,
+} from "../src/mod.ts";
+import { createPluginFixture } from "../src/testing.ts";
+
+Deno.test("plugin manifest defaults enabled and validates relative assets", () => {
+  const manifest = validatePluginManifest({
+    id: "artifact-search",
+    name: "Artifact Search",
+    version: "1.0.0",
+    apiVersion: 1,
+    entrypoints: { psycheros: "./psycheros.ts" },
+    browser: { scripts: ["./web/index.js"] },
+  }, "artifact-search");
+
+  assertEquals(manifest.enabled, true);
+  assertEquals(manifest.browser?.scripts, ["./web/index.js"]);
+});
+
+Deno.test("portable plugin archives reject conventional credential files", () => {
+  assertEquals(isPluginSecretFilename("speech/.env"), true);
+  assertEquals(isPluginSecretFilename("speech/secrets.env"), true);
+  assertEquals(isPluginSecretFilename("speech/secrets.json"), true);
+  assertEquals(isPluginSecretFilename("speech/state/cache.json"), false);
+});
+
+Deno.test("plugin manifest id must match its directory", () => {
+  assertThrows(() =>
+    validatePluginManifest({
+      id: "one",
+      name: "One",
+      version: "1.0.0",
+      apiVersion: 1,
+    }, "two")
+  );
+});
+
+Deno.test("plugin paths reject traversal", () => {
+  assertThrows(() => validatePluginRelativePath("./../outside.ts"));
+  assertThrows(() => validatePluginRelativePath("web/index.js"));
+});
+
+Deno.test("plugin entrypoints allow TypeScript and JavaScript only", () => {
+  assertThrows(() =>
+    validatePluginManifest({
+      id: "speech",
+      name: "Speech",
+      version: "1.0.0",
+      apiVersion: 1,
+      entrypoints: { psycheros: "./psycheros.mjs" },
+    }, "speech")
+  );
+});
+
+Deno.test("plugin directory validator checks declared files", async () => {
+  const parent = await Deno.makeTempDir();
+  const directory = join(parent, "speech");
+  await Deno.mkdir(directory);
+  await Deno.writeTextFile(
+    join(directory, "plugin.json"),
+    JSON.stringify({
+      id: "speech",
+      name: "Speech",
+      version: "1.0.0",
+      apiVersion: 1,
+      entrypoints: { psycheros: "./psycheros.ts" },
+    }),
+  );
+  await Deno.writeTextFile(
+    join(directory, "psycheros.ts"),
+    "export default {};",
+  );
+  assertEquals((await validatePluginDirectory(directory)).id, "speech");
+  await Deno.remove(join(directory, "psycheros.ts"));
+  await assertRejects(() => validatePluginDirectory(directory));
+});
+
+Deno.test("plugin env files apply temporarily outside the executable tree", async () => {
+  const parent = await Deno.makeTempDir();
+  const root = join(parent, "plugins");
+  const secretPath = getPluginEnvPath(root, "speech");
+  await Deno.mkdir(join(secretPath, ".."), { recursive: true });
+  await Deno.writeTextFile(
+    secretPath,
+    "PSYCHEROS_PLUGIN_SPEECH_API_KEY=secret",
+  );
+
+  const applied = await applyPluginEnv(root, "speech");
+  try {
+    assertEquals(
+      applied.env.require("PSYCHEROS_PLUGIN_SPEECH_API_KEY"),
+      "secret",
+    );
+  } finally {
+    applied.restore();
+  }
+  assertEquals(Deno.env.has("PSYCHEROS_PLUGIN_SPEECH_API_KEY"), false);
+});
+
+Deno.test("plugin fixture helper writes isolated code and secrets trees", async () => {
+  const fixture = await createPluginFixture(
+    {
+      id: "speech-fixture",
+      name: "Speech Fixture",
+      version: "1.0.0",
+      apiVersion: 1,
+      entrypoints: { psycheros: "./psycheros.ts" },
+    },
+    { "psycheros.ts": "export default {};" },
+    { PSYCHEROS_PLUGIN_SPEECH_FIXTURE_KEY: "test-only" },
+  );
+
+  assertEquals(
+    await Deno.readTextFile(join(fixture.directory, "psycheros.ts")),
+    "export default {};",
+  );
+  assertEquals(
+    await Deno.readTextFile(
+      join(fixture.secretsDirectory, "speech-fixture.env"),
+    ),
+    "PSYCHEROS_PLUGIN_SPEECH_FIXTURE_KEY=test-only",
+  );
+});

--- a/packages/plugin-api/tests/psycheros_manager_test.ts
+++ b/packages/plugin-api/tests/psycheros_manager_test.ts
@@ -1,0 +1,187 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import type { LLMClient } from "../../psycheros/src/llm/mod.ts";
+import { PluginManager } from "../../psycheros/src/plugins/mod.ts";
+
+async function writePlugin(
+  root: string,
+  id: string,
+  source: string,
+): Promise<void> {
+  const directory = join(root, id);
+  await Deno.mkdir(directory, { recursive: true });
+  await Deno.writeTextFile(
+    join(directory, "plugin.json"),
+    JSON.stringify({
+      id,
+      name: id,
+      version: "1.0.0",
+      apiVersion: 1,
+      entrypoints: { psycheros: "./psycheros.ts" },
+    }),
+  );
+  await Deno.writeTextFile(join(directory, "psycheros.ts"), source);
+}
+
+Deno.test("psycheros prompt hooks run deterministically and expose fallback context", async () => {
+  const root = await Deno.makeTempDir();
+  await writePlugin(
+    root,
+    "later",
+    `export default { promptHooks: [{ name: "later", priority: 20, async run() { return "later"; } }] };`,
+  );
+  await writePlugin(
+    root,
+    "earlier",
+    `export default { promptHooks: [{ name: "earlier", priority: 10, async run() { return "earlier"; } }] };`,
+  );
+  await writePlugin(
+    root,
+    "failed",
+    `export default { promptHooks: [{ name: "failed", async run() { throw new Error("private provider detail"); } }] };`,
+  );
+
+  const manager = new PluginManager(
+    root,
+    () => ({}) as unknown as LLMClient,
+  );
+  await manager.load();
+  const content = await manager.buildPromptContent({
+    conversationId: "conversation",
+    sourceType: "web",
+    userMessage: "hello",
+    sections: {},
+  });
+
+  assert(content);
+  assert(content.indexOf("earlier") < content.indexOf("later"));
+  assert(content.includes("I could not access my failed integration"));
+  assertEquals(content.includes("private provider detail"), false);
+});
+
+Deno.test("psycheros exposes tools, routes, assets, browser tags, and plugin env", async () => {
+  const parent = await Deno.makeTempDir();
+  const root = join(parent, "plugins");
+  await writePlugin(
+    root,
+    "speech",
+    `export default {
+      tools: [{
+        definition: { type: "function", function: { name: "speech_status", description: "I use this to inspect my speech integration.", parameters: { type: "object", properties: {} } } },
+        async execute() { return { success: true }; }
+      }],
+      routes: [{ path: "/speak", handler(_request, services) { return new Response(services.env.require("PSYCHEROS_PLUGIN_SPEECH_API_KEY")); } }],
+      promptHooks: [{ name: "speech", maxChars: 6, async run(ctx) { return ctx.env.require("PSYCHEROS_PLUGIN_SPEECH_API_KEY"); } }]
+    };`,
+  );
+  await Deno.mkdir(join(root, "speech", "web"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "speech", "web", "index.js"),
+    "export {};",
+  );
+  await Deno.writeTextFile(join(root, "speech", "web", "index.css"), "body {}");
+  const manifestPath = join(root, "speech", "plugin.json");
+  const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
+  manifest.browser = {
+    scripts: ["./web/index.js"],
+    styles: ["./web/index.css"],
+  };
+  await Deno.writeTextFile(manifestPath, JSON.stringify(manifest));
+  await Deno.mkdir(join(parent, "plugin-secrets"), { recursive: true });
+  await Deno.writeTextFile(
+    join(parent, "plugin-secrets", "speech.env"),
+    "PSYCHEROS_PLUGIN_SPEECH_API_KEY=elevenlabs-secret",
+  );
+
+  const manager = new PluginManager(root, () => ({}) as unknown as LLMClient);
+  await manager.load();
+  try {
+    assert("speech_status" in manager.getTools());
+    assertStringIncludes(
+      manager.getBrowserHeadHtml(),
+      "/plugins/speech/web/index.js",
+    );
+    assertEquals(
+      await (await manager.handleApiRoute(
+        "speech",
+        "/speak",
+        new Request("http://localhost/api/plugins/speech/speak"),
+      )).text(),
+      "elevenlabs-secret",
+    );
+    assertEquals(
+      await (await manager.serveAsset("speech", "web/index.css")).text(),
+      "body {}",
+    );
+    assertEquals(
+      (await manager.serveAsset("speech", "../outside")).status,
+      403,
+    );
+    const prompt = await manager.buildPromptContent({
+      conversationId: "conversation",
+      sourceType: "web",
+      userMessage: "hello",
+      sections: {},
+    });
+    assertStringIncludes(prompt ?? "", "eleven");
+    assertEquals((prompt ?? "").includes("elevenlabs-secret"), false);
+  } finally {
+    await manager.stop();
+  }
+  assertEquals(Deno.env.has("PSYCHEROS_PLUGIN_SPEECH_API_KEY"), false);
+});
+
+Deno.test("psycheros isolates startup failures, disabled plugins, and hook timeouts", async () => {
+  const root = await Deno.makeTempDir();
+  await writePlugin(root, "broken", `throw new Error("startup detail");`);
+  await Deno.mkdir(join(root, "..", "plugin-secrets"), { recursive: true });
+  await Deno.writeTextFile(
+    join(root, "..", "plugin-secrets", "broken.env"),
+    "PSYCHEROS_PLUGIN_BROKEN_KEY=private",
+  );
+  await writePlugin(root, "healthy", `export default {};`);
+  await writePlugin(
+    root,
+    "slow",
+    `export default { promptHooks: [{ name: "slow", timeoutMs: 1, async run() { await new Promise((resolve) => setTimeout(resolve, 20)); return "late"; } }] };`,
+  );
+  const disabledDirectory = join(root, "disabled");
+  await Deno.mkdir(disabledDirectory, { recursive: true });
+  await Deno.writeTextFile(
+    join(disabledDirectory, "plugin.json"),
+    JSON.stringify({
+      id: "disabled",
+      name: "disabled",
+      version: "1.0.0",
+      apiVersion: 1,
+      enabled: false,
+      entrypoints: { psycheros: "./missing.ts" },
+    }),
+  );
+
+  const manager = new PluginManager(root, () => ({}) as unknown as LLMClient);
+  await manager.load();
+  const statuses = manager.getStatuses();
+  assertEquals(
+    statuses.find((status) => status.id === "broken")?.degraded,
+    true,
+  );
+  assertEquals(Deno.env.has("PSYCHEROS_PLUGIN_BROKEN_KEY"), false);
+  assertEquals(
+    statuses.find((status) => status.id === "healthy")?.active,
+    true,
+  );
+  assertEquals(
+    statuses.find((status) => status.id === "disabled")?.active,
+    false,
+  );
+  const content = await manager.buildPromptContent({
+    conversationId: "conversation",
+    sourceType: "pulse",
+    userMessage: "hello",
+    sections: {},
+  });
+  assertStringIncludes(content ?? "", "I could not access my slow integration");
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  await manager.stop();
+});

--- a/packages/psycheros/CLAUDE.md
+++ b/packages/psycheros/CLAUDE.md
@@ -62,6 +62,17 @@ Custom tools don't need any of the registry wiring above.
 
 The custom-tool loader is in `src/tools/custom-loader.ts`.
 
+## Trusted local plugins
+
+Broader extensions live under `dataRoot/.psycheros/plugins/<id>/`. The Psycheros
+manager is `src/plugins/`; it loads only at startup, merges plugin tools into
+the normal registry, runs prompt hooks after built-in retrieval, and mounts
+plugin routes/assets under namespaced paths. See `docs/plugins.md`. My
+plugin-owned credentials live under
+`dataRoot/.psycheros/plugin-secrets/<id>.env`, outside portable exports. I
+should use `PSYCHEROS_PLUGIN_<ID>_*` names because my trusted plugins share
+process environment.
+
 ## Reactive UI: state-changes
 
 UI updates flow through state-change functions in `src/server/state-changes.ts`.

--- a/packages/psycheros/docs/plugins.md
+++ b/packages/psycheros/docs/plugins.md
@@ -1,0 +1,205 @@
+# Trusted Local Plugins
+
+Plugins extend my Psycheros embodiment and my canonical entity-core without
+forking source. They live under:
+
+```text
+<dataRoot>/.psycheros/plugins/<id>/
+```
+
+Plugins are trusted local code. They can access my filesystem, network,
+database-facing services, and local secrets. Installing or restoring a plugin is
+equivalent to installing executable code. I load plugins only during startup, so
+changes require a daemon restart.
+
+## Secrets And Environment
+
+My plugin credentials live outside the executable plugin tree:
+
+```text
+<dataRoot>/.psycheros/plugin-secrets/<id>.env
+```
+
+For an ElevenLabs speech plugin:
+
+```dotenv
+PSYCHEROS_PLUGIN_SPEECH_ELEVENLABS_API_KEY=...
+PSYCHEROS_PLUGIN_SPEECH_ELEVENLABS_VOICE_ID=...
+```
+
+Both of my hosts apply this file before importing the matching entrypoint. My
+plugin can use `Deno.env.get(...)` directly or the accessor passed to callbacks:
+
+```ts
+export default {
+  start({ env }) {
+    env.require("PSYCHEROS_PLUGIN_SPEECH_ELEVENLABS_API_KEY");
+  },
+  routes: [{
+    method: "POST",
+    path: "/speak",
+    async handler(request, { env }) {
+      const apiKey = env.require(
+        "PSYCHEROS_PLUGIN_SPEECH_ELEVENLABS_API_KEY",
+      );
+      return synthesize(await request.text(), apiKey);
+    },
+  }],
+};
+```
+
+My trusted plugins share a process environment, so names should start with
+`PSYCHEROS_PLUGIN_<ID>_`. Portable entity exports include plugin code and
+`state/`, but never include `plugin-secrets/`. Conventional credential files
+such as `.env`, `secrets.env`, and `secrets.json` are also omitted if they are
+accidentally placed inside my plugin directory. My plugin state may still
+contain sensitive provider data, so I should keep credentials in
+`plugin-secrets/`.
+
+## Manifest
+
+Each directory contains `plugin.json` and optional host entrypoints:
+
+```json
+{
+  "id": "artifact-search",
+  "name": "Artifact Search",
+  "version": "1.0.0",
+  "apiVersion": 1,
+  "enabled": true,
+  "entrypoints": {
+    "psycheros": "./psycheros.ts",
+    "entityCore": "./entity-core.ts"
+  },
+  "browser": {
+    "scripts": ["./web/index.js"],
+    "styles": ["./web/index.css"]
+  }
+}
+```
+
+My directory name must match `id`. Manifest paths are relative, start with `./`,
+and cannot escape the plugin directory.
+
+## Psycheros Entrypoint
+
+`psycheros.ts` exports a default object with optional `tools`, `promptHooks`,
+`routes`, `start`, and `stop` fields. Tools use the existing Psycheros `Tool`
+interface. Routes are mounted under `/api/plugins/<id>/`; browser files are
+served under `/plugins/<id>/`.
+
+```ts
+export default {
+  promptHooks: [{
+    name: "artifact-search",
+    priority: 10,
+    async run(ctx) {
+      const workerSummary = await ctx.completeWorker(
+        `Summarize useful artifacts for: ${ctx.userMessage}`,
+      );
+      return `My retrieved artifacts:\n${workerSummary}`;
+    },
+  }],
+};
+```
+
+Each prompt hook defaults to a 15-second timeout and a 12,000-character output
+limit. A failed hook is skipped and I receive a sanitized system note so I can
+mention the degraded integration naturally.
+
+## Entity-Core Entrypoint
+
+`entity-core.ts` exports optional `tools`, `resultDecorators`, `start`, and
+`stop` fields. Decorators add fields to selected MCP results after core logic
+completes. They cannot replace existing fields.
+
+```ts
+export default {
+  resultDecorators: [{
+    tool: "memory_search",
+    name: "artifact-links",
+    async decorate(result) {
+      return { artifact_links: await lookupLinks(result) };
+    },
+  }],
+};
+```
+
+## Media Patterns
+
+A video-call plugin can inject browser JavaScript, request webcam permission,
+stream frames through its namespaced route, and return avatar state through a
+prompt hook. An audio plugin can use the same route and browser-asset surface
+for microphone capture, speech recognition, synthesis, and playback. These are
+plugin responsibilities; the core harness does not ship a webcam or audio
+provider.
+
+## Testing
+
+My plugins are ordinary Deno modules. I can keep tests beside my plugin and run:
+
+```powershell
+deno test -A
+```
+
+Before restarting after a manual install, I can validate my manifest and every
+declared entrypoint or browser asset from the workspace:
+
+```powershell
+deno task --cwd packages/plugin-api validate <dataRoot>/.psycheros/plugins/speech
+```
+
+`@psycheros/plugin-api/testing` exposes `createPluginFixture()` for isolated
+startup tests with sibling `plugins/` and `plugin-secrets/` directories:
+
+```ts
+import { assertEquals } from "@std/assert";
+import { createPluginFixture } from "@psycheros/plugin-api/testing";
+import { PluginManager } from "<psycheros>/src/plugins/mod.ts";
+
+Deno.test("my speech route uses my configured provider", async () => {
+  const fixture = await createPluginFixture(
+    {
+      id: "speech",
+      name: "Speech",
+      version: "1.0.0",
+      apiVersion: 1,
+      entrypoints: { psycheros: "./psycheros.ts" },
+    },
+    {
+      "psycheros.ts": `export default {
+        routes: [{ path: "/status", handler(_request, { env }) {
+          return Response.json({ configured: env.has("PSYCHEROS_PLUGIN_SPEECH_API_KEY") });
+        }}]
+      };`,
+    },
+    { PSYCHEROS_PLUGIN_SPEECH_API_KEY: "test-only" },
+  );
+
+  const manager = new PluginManager(fixture.root, () => fakeLlm);
+  await manager.load();
+  try {
+    const response = await manager.handleApiRoute(
+      "speech",
+      "/status",
+      new Request("http://localhost/api/plugins/speech/status"),
+    );
+    assertEquals(await response.json(), { configured: true });
+  } finally {
+    await manager.stop();
+  }
+});
+```
+
+My host tests should cover startup failure isolation, lifecycle cleanup, prompt
+timeouts and truncation, sanitized fallbacks, tool registration, route
+namespacing, asset containment, browser tags, MCP decorator collisions, and
+credential restoration after shutdown.
+
+## Existing Custom Tools
+
+The older `custom-tools/` directory remains supported for single-file
+LLM-callable tools. Existing custom tools do not need migration.
+
+All prompt text, tool descriptions, comments, and entity-facing copy follow my
+first-person convention.

--- a/packages/psycheros/src/entity/context.ts
+++ b/packages/psycheros/src/entity/context.ts
@@ -466,6 +466,7 @@ export function buildSystemMessage(
   imageGenContent?: string,
   situationalAwarenessContent?: string,
   discordChannelContent?: string,
+  pluginContent?: string,
 ): string {
   // Build sections — base instructions always first
   const sections: string[] = [];
@@ -517,6 +518,14 @@ ${situationalAwarenessContent}`);
     sections.push(`---
 
 ${discordChannelContent}`);
+  }
+
+  if (pluginContent?.trim()) {
+    sections.push(`---
+
+My plugin context:
+
+${pluginContent}`);
   }
 
   // Add lorebook-triggered content if present

--- a/packages/psycheros/src/entity/loop.ts
+++ b/packages/psycheros/src/entity/loop.ts
@@ -57,6 +57,7 @@ import { buildGraphContext, formatChatHistoryForContext } from "../rag/mod.ts";
 import { generateUIUpdates } from "../server/ui-updates.ts";
 import { acquireLock } from "../utils/conversation-lock.ts";
 import { createCollector, finalize, setFinishReason } from "../metrics/mod.ts";
+import type { PluginManager } from "../plugins/mod.ts";
 
 /**
  * Escape special XML characters in a string.
@@ -263,6 +264,8 @@ export interface EntityConfig {
   contextLength?: number;
   /** Maximum tokens reserved for the response (from active LLM profile) */
   maxTokens?: number;
+  /** Trusted local plugins that can contribute prompt-time context */
+  pluginManager?: PluginManager;
 }
 
 /**
@@ -800,6 +803,22 @@ Discord interaction:
       discordChannelContent = parts.join("\n");
     }
 
+    const pluginContent = await this.config.pluginManager?.buildPromptContent({
+      conversationId,
+      sourceType: options?.sourceType ?? (options?.pulseId ? "pulse" : "web"),
+      userMessage,
+      sections: {
+        memories: memoriesContent,
+        chatHistory: chatHistoryContent,
+        lorebook: lorebookContent,
+        graph: graphContent,
+        vault: vaultContent,
+        situationalAwareness: saContent,
+        discord: discordChannelContent,
+      },
+      mcpClient: this.config.mcpClient,
+    });
+
     const systemMessage = buildSystemMessage(
       baseInstructions,
       selfContent,
@@ -814,6 +833,7 @@ Discord interaction:
       imageGenContent,
       saContent,
       discordChannelContent,
+      pluginContent,
     );
 
     // Get conversation history from DB
@@ -912,6 +932,7 @@ Discord interaction:
         graphContent,
         vaultContent,
         situationalAwarenessContent: saContent,
+        pluginContent,
         messages: messages.slice(1).map((msg) => ({
           role: msg.role,
           content: msg.content,

--- a/packages/psycheros/src/main.ts
+++ b/packages/psycheros/src/main.ts
@@ -142,6 +142,7 @@ if (mcpEnabled) {
     instanceId: mcpInstance,
     env: {
       ENTITY_CORE_DATA_DIR: entityCoreDataDir,
+      PSYCHEROS_PLUGIN_DIR: join(config.dataRoot, ".psycheros", "plugins"),
       // Entity-core LLM settings — prefer entity-core override, then active profile, then ZAI_* vars
       ENTITY_CORE_LLM_API_KEY: Deno.env.get("ENTITY_CORE_LLM_API_KEY") ||
         activeProfile?.apiKey || Deno.env.get("ZAI_API_KEY") || "",
@@ -198,7 +199,7 @@ async function shutdown() {
     await mcpClient.disconnect();
   }
 
-  server.stop();
+  await server.stop();
   Deno.exit(0);
 }
 

--- a/packages/psycheros/src/mcp-client/mod.ts
+++ b/packages/psycheros/src/mcp-client/mod.ts
@@ -11,6 +11,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { join } from "@std/path";
 import type { Granularity } from "../memory/types.ts";
 import { getBroadcaster } from "../server/broadcaster.ts";
+import type { PluginStatus } from "../../../plugin-api/src/mod.ts";
 
 /**
  * Read the entity-core child's PID out of the MCP SDK's StdioClientTransport.
@@ -1775,6 +1776,22 @@ export class MCPClient {
     } catch (error) {
       console.error("[MCP] Get extraction health failed:", error);
       return null;
+    }
+  }
+
+  /**
+   * Get trusted local plugin activation status from entity-core.
+   */
+  async getPluginStatuses(): Promise<PluginStatus[]> {
+    if (!this.client) return [];
+
+    try {
+      const result = await this.callToolWithTimeout("plugin_status", {});
+      const textContent = extractTextContent(result);
+      return textContent ? JSON.parse(textContent) : [];
+    } catch (error) {
+      console.error("[MCP] Get plugin status failed:", error);
+      return [];
     }
   }
 

--- a/packages/psycheros/src/plugins/mod.ts
+++ b/packages/psycheros/src/plugins/mod.ts
@@ -1,0 +1,6 @@
+export { createPluginManager, PluginManager } from "./plugin-manager.ts";
+export type {
+  PluginPromptContext,
+  PluginPromptHook,
+  PluginRoute,
+} from "./plugin-manager.ts";

--- a/packages/psycheros/src/plugins/plugin-manager.ts
+++ b/packages/psycheros/src/plugins/plugin-manager.ts
@@ -1,0 +1,388 @@
+/**
+ * Trusted local plugin harness for my Psycheros embodiment.
+ */
+
+import { basename, extname, join, normalize, toFileUrl } from "@std/path";
+import {
+  type AppliedPluginEnv,
+  applyPluginEnv,
+  DEFAULT_PROMPT_HOOK_MAX_CHARS,
+  DEFAULT_PROMPT_HOOK_TIMEOUT_MS,
+  emptyPluginCapabilityCounts,
+  type PluginEnv,
+  type PluginManifest,
+  type PluginStatus,
+  validatePluginManifest,
+  validatePluginRelativePath,
+} from "../../../plugin-api/src/mod.ts";
+import type { Tool } from "../tools/mod.ts";
+import type { MCPClient } from "../mcp-client/mod.ts";
+import type { LLMClient } from "../llm/mod.ts";
+
+export interface PluginPromptContext {
+  conversationId: string;
+  sourceType: "web" | "discord" | "pulse";
+  userMessage: string;
+  sections: Record<string, string | undefined>;
+  statePath: string;
+  env: PluginEnv;
+  mcpClient?: MCPClient;
+  completeWorker: (prompt: string, systemPrompt?: string) => Promise<string>;
+}
+
+export interface PsycherosPluginServices {
+  statePath: string;
+  env: PluginEnv;
+}
+
+export interface PluginPromptHook {
+  name: string;
+  priority?: number;
+  timeoutMs?: number;
+  maxChars?: number;
+  run: (context: PluginPromptContext) => Promise<string | undefined>;
+}
+
+export interface PluginRoute {
+  method?: string;
+  path: string;
+  handler: (
+    request: Request,
+    services: PsycherosPluginServices,
+  ) => Response | Promise<Response>;
+}
+
+interface PsycherosPluginModule {
+  tools?: Tool[];
+  promptHooks?: PluginPromptHook[];
+  routes?: PluginRoute[];
+  start?: (services: PsycherosPluginServices) => void | Promise<void>;
+  stop?: (services: PsycherosPluginServices) => void | Promise<void>;
+}
+
+interface LoadedPlugin {
+  directory: string;
+  manifest: PluginManifest;
+  module?: PsycherosPluginModule;
+  appliedEnv?: AppliedPluginEnv;
+  status: PluginStatus;
+}
+
+function getMimeType(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case ".js":
+    case ".mjs":
+      return "application/javascript; charset=utf-8";
+    case ".css":
+      return "text/css; charset=utf-8";
+    case ".json":
+      return "application/json; charset=utf-8";
+    case ".svg":
+      return "image/svg+xml";
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".webp":
+      return "image/webp";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function safeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class PluginManager {
+  private plugins: LoadedPlugin[] = [];
+
+  constructor(
+    private pluginRoot: string,
+    private getLlm: () => LLMClient,
+  ) {}
+
+  private services(plugin: LoadedPlugin): PsycherosPluginServices {
+    return {
+      statePath: join(plugin.directory, "state"),
+      env: plugin.appliedEnv?.env ?? {
+        get: (name) => Deno.env.get(name),
+        has: (name) => Deno.env.has(name),
+        require(name) {
+          const value = Deno.env.get(name);
+          if (!value) {
+            throw new Error(`missing required plugin environment: ${name}`);
+          }
+          return value;
+        },
+      },
+    };
+  }
+
+  async load(): Promise<void> {
+    await this.stop();
+    this.plugins = [];
+    let entries: Deno.DirEntry[];
+    try {
+      entries = Array.from(Deno.readDirSync(this.pluginRoot));
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return;
+      throw error;
+    }
+
+    for (const entry of entries.filter((item) => item.isDirectory)) {
+      const directory = join(this.pluginRoot, entry.name);
+      let appliedEnv: AppliedPluginEnv | undefined;
+      try {
+        const raw = JSON.parse(
+          await Deno.readTextFile(join(directory, "plugin.json")),
+        );
+        const manifest = validatePluginManifest(raw, entry.name);
+        const capabilities = emptyPluginCapabilityCounts();
+        capabilities.browserScripts = manifest.browser?.scripts?.length ?? 0;
+        capabilities.browserStyles = manifest.browser?.styles?.length ?? 0;
+        const status: PluginStatus = {
+          id: manifest.id,
+          name: manifest.name,
+          version: manifest.version,
+          enabled: manifest.enabled,
+          active: false,
+          degraded: false,
+          restartRequired: false,
+          entrypoints: {
+            psycheros: !!manifest.entrypoints?.psycheros,
+            entityCore: !!manifest.entrypoints?.entityCore,
+          },
+          capabilities,
+        };
+        const loaded: LoadedPlugin = { directory, manifest, status };
+        this.plugins.push(loaded);
+        if (!manifest.enabled || !manifest.entrypoints?.psycheros) continue;
+
+        appliedEnv = await applyPluginEnv(this.pluginRoot, manifest.id);
+        loaded.appliedEnv = appliedEnv;
+        const entrypoint = validatePluginRelativePath(
+          manifest.entrypoints.psycheros,
+        );
+        const imported = await import(
+          toFileUrl(join(directory, entrypoint)).href
+        );
+        const module = (imported.default ?? imported) as PsycherosPluginModule;
+        loaded.module = module;
+        status.capabilities.tools = module.tools?.length ?? 0;
+        status.capabilities.promptHooks = module.promptHooks?.length ?? 0;
+        status.capabilities.routes = module.routes?.length ?? 0;
+        status.active = true;
+        await module.start?.(this.services(loaded));
+      } catch (error) {
+        appliedEnv?.restore();
+        console.error(`[Plugins] Failed to load ${entry.name}:`, error);
+        this.plugins = this.plugins.filter((plugin) =>
+          plugin.manifest.id !== entry.name
+        );
+        this.plugins.push({
+          directory,
+          manifest: {
+            id: entry.name,
+            name: entry.name,
+            version: "unknown",
+            apiVersion: 1,
+            enabled: false,
+          },
+          status: {
+            id: entry.name,
+            name: entry.name,
+            version: "unknown",
+            enabled: false,
+            active: false,
+            degraded: true,
+            restartRequired: false,
+            entrypoints: { psycheros: false, entityCore: false },
+            capabilities: emptyPluginCapabilityCounts(),
+            lastError: safeError(error),
+          },
+        });
+      }
+    }
+    this.plugins.sort((a, b) => a.manifest.id.localeCompare(b.manifest.id));
+  }
+
+  async stop(): Promise<void> {
+    for (const plugin of [...this.plugins].reverse()) {
+      try {
+        await plugin.module?.stop?.(this.services(plugin));
+      } catch (error) {
+        console.error(`[Plugins] Failed to stop ${plugin.manifest.id}:`, error);
+      } finally {
+        plugin.appliedEnv?.restore();
+        plugin.appliedEnv = undefined;
+      }
+    }
+  }
+
+  getStatuses(): PluginStatus[] {
+    return this.plugins.map((plugin) => ({ ...plugin.status }));
+  }
+
+  getTools(): Record<string, Tool> {
+    const tools: Record<string, Tool> = {};
+    for (const plugin of this.plugins) {
+      for (const tool of plugin.module?.tools ?? []) {
+        tools[tool.definition.function.name] = tool;
+      }
+    }
+    return tools;
+  }
+
+  getBrowserHeadHtml(): string {
+    const tags: string[] = [];
+    for (const plugin of this.plugins) {
+      if (!plugin.status.active) continue;
+      for (const path of plugin.manifest.browser?.styles ?? []) {
+        tags.push(
+          `<link rel="stylesheet" href="/plugins/${plugin.manifest.id}/${
+            validatePluginRelativePath(path)
+          }">`,
+        );
+      }
+      for (const path of plugin.manifest.browser?.scripts ?? []) {
+        tags.push(
+          `<script type="module" src="/plugins/${plugin.manifest.id}/${
+            validatePluginRelativePath(path)
+          }"></script>`,
+        );
+      }
+    }
+    return tags.join("\n  ");
+  }
+
+  async buildPromptContent(
+    context: Omit<PluginPromptContext, "statePath" | "env" | "completeWorker">,
+  ): Promise<string | undefined> {
+    const contributions: string[] = [];
+    const hooks = this.plugins.flatMap((plugin) =>
+      (plugin.module?.promptHooks ?? []).map((hook) => ({ plugin, hook }))
+    ).sort((a, b) =>
+      (a.hook.priority ?? 0) - (b.hook.priority ?? 0) ||
+      a.plugin.manifest.id.localeCompare(b.plugin.manifest.id) ||
+      a.hook.name.localeCompare(b.hook.name)
+    );
+
+    for (const { plugin, hook } of hooks) {
+      const timeoutMs = hook.timeoutMs ??
+        plugin.manifest.promptHookDefaults?.timeoutMs ??
+        DEFAULT_PROMPT_HOOK_TIMEOUT_MS;
+      const maxChars = hook.maxChars ??
+        plugin.manifest.promptHookDefaults?.maxChars ??
+        DEFAULT_PROMPT_HOOK_MAX_CHARS;
+      let timeoutId: number | undefined;
+      try {
+        const output = await Promise.race([
+          hook.run({
+            ...context,
+            statePath: join(plugin.directory, "state"),
+            env: this.services(plugin).env,
+            completeWorker: async (prompt, systemPrompt) => {
+              const messages = [];
+              if (systemPrompt) {
+                messages.push({
+                  role: "system" as const,
+                  content: systemPrompt,
+                });
+              }
+              messages.push({ role: "user" as const, content: prompt });
+              let content = "";
+              for await (const chunk of this.getLlm().chatStream(messages)) {
+                if (chunk.type === "content") content += chunk.content;
+              }
+              return content;
+            },
+          }),
+          new Promise<never>((_, reject) =>
+            timeoutId = setTimeout(
+              () => reject(new Error(`hook timed out after ${timeoutMs}ms`)),
+              timeoutMs,
+            )
+          ),
+        ]);
+        if (output?.trim()) {
+          contributions.push(
+            `<plugin_context source="${plugin.manifest.id}" hook="${hook.name}">\n${
+              output.trim().slice(0, maxChars)
+            }\n</plugin_context>`,
+          );
+        }
+      } catch (error) {
+        plugin.status.degraded = true;
+        plugin.status.lastError = safeError(error);
+        console.error(
+          `[Plugins] Prompt hook ${plugin.manifest.id}/${hook.name} failed:`,
+          error,
+        );
+        contributions.push(
+          `<plugin_failure source="${plugin.manifest.id}">\nI could not access my ${plugin.manifest.name} integration during this turn. I should mention that naturally if it affects my response.\n</plugin_failure>`,
+        );
+      } finally {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+      }
+    }
+    return contributions.length > 0 ? contributions.join("\n\n") : undefined;
+  }
+
+  async handleApiRoute(
+    pluginId: string,
+    subpath: string,
+    request: Request,
+  ): Promise<Response> {
+    const plugin = this.plugins.find((item) =>
+      item.manifest.id === pluginId && item.status.active
+    );
+    if (!plugin) return new Response("Not Found", { status: 404 });
+    const method = request.method.toUpperCase();
+    const route = plugin.module?.routes?.find((item) =>
+      (item.method?.toUpperCase() ?? "GET") === method &&
+      item.path === subpath
+    );
+    return route
+      ? await route.handler(request, this.services(plugin))
+      : new Response("Not Found", { status: 404 });
+  }
+
+  async serveAsset(pluginId: string, relativePath: string): Promise<Response> {
+    const plugin = this.plugins.find((item) =>
+      item.manifest.id === pluginId && item.status.active
+    );
+    if (!plugin) return new Response("Not Found", { status: 404 });
+    let safePath: string;
+    try {
+      safePath = validatePluginRelativePath(`./${relativePath}`);
+    } catch {
+      return new Response("Forbidden", { status: 403 });
+    }
+    const root = normalize(plugin.directory);
+    const filePath = normalize(join(root, safePath));
+    if (!filePath.startsWith(root + "\\") && !filePath.startsWith(root + "/")) {
+      return new Response("Forbidden", { status: 403 });
+    }
+    try {
+      return new Response(await Deno.readFile(filePath), {
+        headers: {
+          "Content-Type": getMimeType(filePath),
+          "Cache-Control": "no-cache",
+        },
+      });
+    } catch (error) {
+      return error instanceof Deno.errors.NotFound
+        ? new Response("Not Found", { status: 404 })
+        : new Response(`Failed to read ${basename(filePath)}`, { status: 500 });
+    }
+  }
+}
+
+export function createPluginManager(
+  pluginRoot: string,
+  getLlm: () => LLMClient,
+): PluginManager {
+  return new PluginManager(pluginRoot, getLlm);
+}

--- a/packages/psycheros/src/pulse/engine.ts
+++ b/packages/psycheros/src/pulse/engine.ts
@@ -127,6 +127,7 @@ export interface PulseEngineConfig {
     | undefined;
   contextLength?: () => number | undefined;
   maxTokens?: () => number | undefined;
+  pluginManager?: import("../plugins/mod.ts").PluginManager;
 }
 
 // =============================================================================
@@ -682,6 +683,7 @@ export class PulseEngine {
       deviceStatusCache: this.config.deviceStatusCache?.(),
       contextLength: this.config.contextLength?.(),
       maxTokens: this.config.maxTokens?.(),
+      pluginManager: this.config.pluginManager,
     };
 
     const turn = new EntityTurn(

--- a/packages/psycheros/src/server/admin-templates.ts
+++ b/packages/psycheros/src/server/admin-templates.ts
@@ -752,8 +752,10 @@ export function renderAdminEntityData(): string {
     <h3 class="admin-section-title">Export Entity Data</h3>
     <p class="admin-action-desc">
       Exports all entity data (identity, memories, knowledge graph, conversations,
-      lorebooks, vault documents, images) as a zip file. Entity-core data is
-      fetched via MCP; Psycheros data is exported directly.
+      lorebooks, vault documents, images, and trusted local plugins) as a zip
+      file. Entity-core data is fetched via MCP; Psycheros data is exported
+      directly. Plugin code can access my filesystem, network, services, and
+      local secrets available after restart.
     </p>
     <div class="admin-action-form">
       <button id="admin-export-btn" class="admin-action-btn" onclick="window.adminExportEntity()">
@@ -773,7 +775,8 @@ export function renderAdminEntityData(): string {
       Performs a <strong>full overwrite</strong> of all entity data from a Psycheros
       entity zip file. A snapshot is taken before overwriting entity-core data.
       After import, stale RAG indexes are cleared and will be rebuilt on next access.
-      The import requires MCP to be connected for entity-core data.
+      The import requires MCP to be connected for entity-core data. Restored
+      plugins are executable local code and take effect after I restart.
     </p>
     <div class="admin-action-form">
       <div class="admin-action-fields">

--- a/packages/psycheros/src/server/entity-data.ts
+++ b/packages/psycheros/src/server/entity-data.ts
@@ -9,6 +9,7 @@
  */
 
 import JSZip from "jszip";
+import { isPluginSecretFilename } from "../../../plugin-api/src/mod.ts";
 import { isAbsolute, join } from "@std/path";
 import { ensureDir } from "@std/fs";
 import type { RouteContext } from "./routes.ts";
@@ -50,6 +51,8 @@ export interface ImportResult {
       vault_documents_restored?: number;
       images_restored?: number;
       anchor_images_restored?: number;
+      plugins_restored?: number;
+      plugin_restart_required?: boolean;
     };
     entity_core?: {
       success: boolean;
@@ -86,6 +89,42 @@ function execSql(
   } else {
     ctx.db.getRawDb().exec(sql, params);
   }
+}
+
+function isSafeArchivePath(path: string): boolean {
+  const normalized = path.replace(/\\/g, "/");
+  return normalized.length > 0 &&
+    !normalized.startsWith("/") &&
+    !normalized.split("/").some((part) => part === ".." || part === "");
+}
+
+async function addDirectoryToZip(
+  zip: JSZip,
+  sourceDir: string,
+  archivePrefix: string,
+  includeFile: (path: string) => boolean = () => true,
+): Promise<number> {
+  let count = 0;
+  try {
+    for await (const entry of Deno.readDir(sourceDir)) {
+      const diskPath = join(sourceDir, entry.name);
+      const archivePath = `${archivePrefix}/${entry.name}`;
+      if (entry.isDirectory) {
+        count += await addDirectoryToZip(
+          zip,
+          diskPath,
+          archivePath,
+          includeFile,
+        );
+      } else if (entry.isFile && includeFile(archivePath)) {
+        zip.file(archivePath, await Deno.readFile(diskPath));
+        count++;
+      }
+    }
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) throw error;
+  }
+  return count;
 }
 
 /**
@@ -213,6 +252,7 @@ export async function exportEntityData(
   let lorebookEntryCount = 0;
   let vaultDocCount = 0;
   let imageCount = 0;
+  let pluginFileCount = 0;
 
   // Conversations + messages
   const conversations = queryAll<
@@ -411,6 +451,13 @@ export async function exportEntityData(
     // generated-images directory absent — nothing to export
   }
 
+  pluginFileCount = await addDirectoryToZip(
+    zip,
+    join(ctx.dataRoot, ".psycheros", "plugins"),
+    "psycheros/plugins",
+    (path) => !isPluginSecretFilename(path),
+  );
+
   // Build manifest
   const manifest: Record<string, unknown> = {
     schema_version: 1,
@@ -425,6 +472,7 @@ export async function exportEntityData(
         lorebooks: true,
         vault: true,
         images: true,
+        plugins: true,
       },
     },
     counts: {
@@ -435,6 +483,7 @@ export async function exportEntityData(
       lorebook_entries: lorebookEntryCount,
       vault_documents: vaultDocCount,
       images: imageCount,
+      plugin_files: pluginFileCount,
     },
   };
 
@@ -868,6 +917,37 @@ export async function importEntityData(
 
         details.psycheros.anchor_images_restored = anchors.length;
       }
+    }
+
+    if (psycherosParts.plugins) {
+      const pluginsPrefix = "psycheros/plugins/";
+      const pluginsDir = join(ctx.dataRoot, ".psycheros", "plugins");
+      await progress({
+        phase: "plugins",
+        status: "Restoring trusted local plugins...",
+      });
+      await Deno.remove(pluginsDir, { recursive: true }).catch((error) => {
+        if (!(error instanceof Deno.errors.NotFound)) throw error;
+      });
+      await ensureDir(pluginsDir);
+
+      let pluginFileCount = 0;
+      for (const [filename, file] of Object.entries(zip.files)) {
+        if (file.dir || !filename.startsWith(pluginsPrefix)) continue;
+        const relative = filename.slice(pluginsPrefix.length);
+        if (!isSafeArchivePath(relative)) {
+          return {
+            success: false,
+            error: `Invalid plugin archive path: ${filename}`,
+          };
+        }
+        const destination = join(pluginsDir, ...relative.split("/"));
+        await ensureDir(join(destination, ".."));
+        await Deno.writeFile(destination, await file.async("uint8array"));
+        pluginFileCount++;
+      }
+      details.psycheros.plugins_restored = pluginFileCount;
+      details.psycheros.plugin_restart_required = pluginFileCount > 0;
     }
 
     // --- Import entity-core data via MCP ---

--- a/packages/psycheros/src/server/routes.ts
+++ b/packages/psycheros/src/server/routes.ts
@@ -155,6 +155,7 @@ import { getServerStartTime } from "./diagnostics.ts";
 import entityCoreDenoJson from "../../../entity-core/deno.json" with {
   type: "json",
 };
+import type { PluginManager } from "../plugins/mod.ts";
 
 /**
  * Context passed to route handlers containing dependencies.
@@ -261,6 +262,8 @@ export interface RouteContext {
   getDeviceStatusCache: () => import("./device-cache.ts").DeviceStatusCache;
   /** Custom tools loaded from custom-tools/ directory */
   customTools: Record<string, import("../tools/types.ts").Tool>;
+  /** Trusted local plugin harness */
+  pluginManager: PluginManager;
 }
 
 /**
@@ -379,8 +382,8 @@ function normalizePath(path: string): string {
  * @param _ctx - Route context (unused, kept for consistency)
  * @returns HTTP Response with the app shell HTML
  */
-export function handleIndex(_ctx: RouteContext): Response {
-  const html = renderAppShell();
+export function handleIndex(ctx: RouteContext): Response {
+  const html = renderAppShell(ctx.pluginManager.getBrowserHeadHtml());
   return new Response(html, {
     headers: {
       "Content-Type": "text/html; charset=utf-8",
@@ -483,7 +486,7 @@ export function handleConversationView(
 
   // Always return the full app shell
   // Frontend JS will load the conversation content via /fragments/chat/:id
-  const html = renderAppShell();
+  const html = renderAppShell(ctx.pluginManager.getBrowserHeadHtml());
   return new Response(html, {
     headers: {
       "Content-Type": "text/html; charset=utf-8",
@@ -1235,6 +1238,7 @@ export async function handleChat(
             deviceStatusCache: ctx.getDeviceStatusCache(),
             contextLength: activeProfile?.contextLength,
             maxTokens: activeProfile?.maxTokens,
+            pluginManager: ctx.pluginManager,
           },
         );
 
@@ -1426,6 +1430,7 @@ export async function handleChatRetry(
             deviceStatusCache: ctx.getDeviceStatusCache(),
             contextLength: retryProfile?.contextLength,
             maxTokens: retryProfile?.maxTokens,
+            pluginManager: ctx.pluginManager,
           },
         );
 

--- a/packages/psycheros/src/server/server.ts
+++ b/packages/psycheros/src/server/server.ts
@@ -87,6 +87,8 @@ import {
 } from "../discord/mod.ts";
 import { join } from "@std/path";
 import { MAX_REQUEST_BODY_SIZE, MAX_UPLOAD_BODY_SIZE } from "../constants.ts";
+import { createPluginManager, type PluginManager } from "../plugins/mod.ts";
+import type { PluginStatus } from "../../../plugin-api/src/mod.ts";
 import {
   handleBatchDeleteConversations,
   handleButtplugStatus,
@@ -363,6 +365,7 @@ export class Server {
   private toolSettings: ToolsSettings;
   private entityCoreLLMSettings: EntityCoreLLMSettings;
   private customTools: Record<string, import("../tools/types.ts").Tool>;
+  private pluginManager: PluginManager;
   private pulseEngine: PulseEngine | null = null;
   private scheduler: Scheduler | null = null;
   private deviceCache: DeviceStatusCache;
@@ -427,6 +430,10 @@ export class Server {
 
     // Initialize custom tools (will be loaded in init())
     this.customTools = {};
+    this.pluginManager = createPluginManager(
+      join(config.dataRoot, ".psycheros", "plugins"),
+      () => this.llm,
+    );
 
     // Initialize tool registry with only allowed tools
     this.tools = createDefaultRegistry(config.allowedTools ?? []);
@@ -494,6 +501,7 @@ export class Server {
     );
     this.toolSettings = await loadToolsSettings(this.config.dataRoot);
     this.customTools = await loadCustomTools(this.config.dataRoot);
+    await this.pluginManager.load();
     this.reloadLLMClient();
     this.reloadToolRegistry();
 
@@ -867,6 +875,7 @@ export class Server {
         deviceStatusCache: this.deviceCache,
         contextLength: activeProfile?.contextLength,
         maxTokens: activeProfile?.maxTokens,
+        pluginManager: this.pluginManager,
       },
     );
 
@@ -1078,6 +1087,7 @@ export class Server {
     const allTools: Record<string, import("../tools/types.ts").Tool> = {
       ...AVAILABLE_TOOLS,
       ...this.customTools,
+      ...this.pluginManager.getTools(),
     };
     const allNames = Object.keys(allTools);
 
@@ -1421,6 +1431,7 @@ export class Server {
         contextLength: () => this.getActiveLLMProfile()?.contextLength,
         maxTokens: () => this.getActiveLLMProfile()?.maxTokens,
         deviceStatusCache: () => this.deviceCache,
+        pluginManager: this.pluginManager,
       },
     );
     this.pulseEngine.start();
@@ -1478,11 +1489,51 @@ export class Server {
   }
 
   /**
+   * Merge activation state from my embodiment and my canonical core.
+   */
+  private async getPluginStatuses(): Promise<PluginStatus[]> {
+    const statuses = new Map(
+      this.pluginManager.getStatuses().map((status) => [status.id, status]),
+    );
+    const coreStatuses = await this.mcpClient?.getPluginStatuses() ?? [];
+
+    for (const coreStatus of coreStatuses) {
+      const localStatus = statuses.get(coreStatus.id);
+      if (!localStatus) {
+        statuses.set(coreStatus.id, coreStatus);
+        continue;
+      }
+      statuses.set(coreStatus.id, {
+        ...localStatus,
+        active: localStatus.active || coreStatus.active,
+        degraded: localStatus.degraded || coreStatus.degraded,
+        lastError: localStatus.lastError ?? coreStatus.lastError,
+        capabilities: {
+          tools: localStatus.capabilities.tools +
+            coreStatus.capabilities.tools,
+          promptHooks: localStatus.capabilities.promptHooks +
+            coreStatus.capabilities.promptHooks,
+          routes: localStatus.capabilities.routes +
+            coreStatus.capabilities.routes,
+          resultDecorators: localStatus.capabilities.resultDecorators +
+            coreStatus.capabilities.resultDecorators,
+          browserScripts: localStatus.capabilities.browserScripts +
+            coreStatus.capabilities.browserScripts,
+          browserStyles: localStatus.capabilities.browserStyles +
+            coreStatus.capabilities.browserStyles,
+        },
+      });
+    }
+
+    return [...statuses.values()].sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  /**
    * Stop the server gracefully.
    *
    * Aborts the server, clears the keepalive timer, and closes the database connection.
    */
-  stop(): void {
+  async stop(): Promise<void> {
     console.log("Stopping Psycheros server...");
 
     // Stop Discord Gateway
@@ -1500,6 +1551,7 @@ export class Server {
 
     // Stop device status cache refresh
     this.deviceCache.stop();
+    await this.pluginManager.stop();
 
     // Clear keepalive timer
     if (this.keepaliveInterval !== null) {
@@ -1565,6 +1617,7 @@ export class Server {
         this.updateEntityCoreLLMSettings(settings),
       getDeviceStatusCache: () => this.deviceCache,
       customTools: this.customTools,
+      pluginManager: this.pluginManager,
     };
   }
 
@@ -1666,6 +1719,19 @@ export class Server {
     // GET /api/events - Persistent SSE event stream
     if (method === "GET" && path === "/api/events") {
       return handleEvents(ctx, request);
+    }
+
+    if (method === "GET" && path === "/api/plugins") {
+      return Response.json(await this.getPluginStatuses());
+    }
+
+    const pluginApiMatch = path.match(/^\/api\/plugins\/([^/]+)(\/.*)?$/);
+    if (pluginApiMatch) {
+      return await this.pluginManager.handleApiRoute(
+        pluginApiMatch[1],
+        pluginApiMatch[2] ?? "/",
+        request,
+      );
     }
 
     // GET /api/conversations - List conversations (JSON)
@@ -3053,6 +3119,14 @@ export class Server {
       return handleToolsSettingsFragment(ctx);
     }
 
+    if (path === "/fragments/settings/plugins") {
+      const { renderPluginsSettings } = await import("./templates.ts");
+      return new Response(
+        renderPluginsSettings(await this.getPluginStatuses()),
+        { headers: { "Content-Type": "text/html; charset=utf-8" } },
+      );
+    }
+
     // ========================================
     // Pulse Fragment Routes
     // ========================================
@@ -3123,6 +3197,14 @@ export class Server {
     if (path.startsWith("/backgrounds/")) {
       const filename = path.replace("/backgrounds/", "");
       return await handleServeBackground(ctx, filename);
+    }
+
+    const pluginAssetMatch = path.match(/^\/plugins\/([^/]+)\/(.+)$/);
+    if (pluginAssetMatch) {
+      return await this.pluginManager.serveAsset(
+        pluginAssetMatch[1],
+        pluginAssetMatch[2],
+      );
     }
 
     // Serve static files from web/ directory

--- a/packages/psycheros/src/server/templates.ts
+++ b/packages/psycheros/src/server/templates.ts
@@ -39,6 +39,7 @@ import type { Tool } from "../tools/mod.ts";
 import { renderMarkdown } from "./markdown.ts";
 import { pulseIconSvg } from "../pulse/templates.ts";
 import type { ExtractionHealth } from "../mcp-client/mod.ts";
+import type { PluginStatus } from "../../../plugin-api/src/mod.ts";
 
 // =============================================================================
 // Utilities
@@ -250,7 +251,7 @@ function getAccentColorOverride(): string {
  * Render the full app shell HTML.
  * This is served on initial page load.
  */
-export function renderAppShell(): string {
+export function renderAppShell(pluginHeadHtml = ""): string {
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -270,6 +271,7 @@ export function renderAppShell(): string {
   <script src="/lib/htmx-sse.js"></script>
   <script src="/lib/marked.min.js"></script>
   <script src="/lib/dompurify.min.js"></script>
+  ${pluginHeadHtml}
 </head>
 <body>
   <div class="bg-layer"></div>
@@ -693,6 +695,24 @@ export function renderSettingsHub(): string {
         </svg>
       </a>
       <a class="settings-hub-card"
+        hx-get="/fragments/settings/plugins"
+        hx-target="#chat"
+        hx-swap="innerHTML">
+        <div class="settings-hub-card-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M8 3v4M16 3v4M5 7h14v5a7 7 0 0 1-14 0V7z"/>
+            <path d="M12 19v3"/>
+          </svg>
+        </div>
+        <div class="settings-hub-card-body">
+          <span class="settings-hub-card-title">Plugins</span>
+          <span class="settings-hub-card-desc">Review trusted local extensions and their runtime status</span>
+        </div>
+        <svg class="settings-hub-card-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <polyline points="9 18 15 12 9 6"/>
+        </svg>
+      </a>
+      <a class="settings-hub-card"
         hx-get="/fragments/settings/llm"
         hx-target="#chat"
         hx-swap="innerHTML">
@@ -734,6 +754,60 @@ export function renderSettingsHub(): string {
     </div>
   </div>
 </div>`;
+}
+
+export function renderPluginsSettings(statuses: PluginStatus[]): string {
+  const rows = statuses.length === 0
+    ? `<p class="settings-note">I do not have any local plugins installed.</p>`
+    : statuses.map((status) => {
+      const state = status.degraded
+        ? "Degraded"
+        : status.active
+        ? "Active"
+        : status.enabled
+        ? "Inactive"
+        : "Disabled";
+      const capabilities = Object.entries(status.capabilities)
+        .filter(([, count]) => count > 0)
+        .map(([name, count]) => `${name}: ${count}`)
+        .join(", ") || "No registered capabilities";
+      return `<section class="theme-section">
+        <h3 class="theme-section-title">${escapeHtml(status.name)} <code>${
+        escapeHtml(status.version)
+      }</code></h3>
+        <p class="theme-section-desc">${escapeHtml(state)}. ${
+        escapeHtml(capabilities)
+      }.</p>
+        <p class="settings-note">Psycheros entrypoint: ${
+        status.entrypoints.psycheros ? "yes" : "no"
+      } · Entity-core entrypoint: ${
+        status.entrypoints.entityCore ? "yes" : "no"
+      }</p>
+        ${
+        status.lastError
+          ? `<p class="settings-note">Last error: ${
+            escapeHtml(status.lastError)
+          }</p>`
+          : ""
+      }
+      </section>`;
+    }).join("");
+
+  return `<div class="settings-view">
+    <div class="settings-header">
+      <div class="settings-header-row">
+        ${renderSettingsBackButton()}
+        <div>
+          <h1 class="settings-title">Plugins</h1>
+          <p class="settings-desc">Trusted local extensions loaded from my persistent data directory</p>
+        </div>
+      </div>
+    </div>
+    <div class="settings-content" id="settings-content">
+      <p class="settings-note">Plugins run as trusted local code. They can access my filesystem, network, services, and local secrets. Portable exports do not include my plugin-secrets directory. Changes take effect after I restart.</p>
+      ${rows}
+    </div>
+  </div>`;
 }
 
 export interface GeneralSettings {

--- a/packages/psycheros/src/types.ts
+++ b/packages/psycheros/src/types.ts
@@ -210,6 +210,8 @@ export interface LLMContextSnapshot {
   vaultContent?: string;
   /** Situational awareness content injected into context */
   situationalAwarenessContent?: string;
+  /** Trusted local plugin context injected into the system prompt */
+  pluginContent?: string;
   /** The messages array sent to the LLM (excluding system) */
   messages: Array<{
     role: string;


### PR DESCRIPTION
## Summary

Adds a trusted, in-process custom plugin harness so local extensions can survive upstream updates without requiring forks. Plugins can extend Psycheros prompt construction, tools, routes, browser assets, and lifecycle hooks, while entity-core plugins can add MCP tools and additive result decorators.

Plugin-owned credentials live outside portable backups under `.psycheros/plugin-secrets/<id>.env`. The shared plugin API includes validation, isolated test fixtures, focused coverage, and a manual-install validator.

## Affected packages

- [x] `packages/psycheros`
- [x] `packages/entity-core`
- [ ] `packages/entity-loom`
- [ ] `packages/launcher`
- [x] Workspace root / CI / docs

Also updates `packages/launcher-v2` backup warnings and rollback-preservation coverage.

## Checklist

- [x] `deno check` passes for the affected entry points
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] First-person convention preserved in any new prompts / comments / docs
- [x] If a behavior changed, the relevant `docs/` or `CLAUDE.md` is updated
- [x] If a new external dependency was added, it's justified in the description

No new external dependency was added. The shared API uses the existing hoisted `@std/dotenv` dependency.

## Related issues