### PR TITLE
Fix conv list refresh

### DIFF
--- a/packages/psycheros/src/server/templates.ts
+++ b/packages/psycheros/src/server/templates.ts
@@ -1515,7 +1515,7 @@ export function renderSidebar(conversations: Conversation[]): string {
     <span class="sidebar-title">Conversations</span>
     <button class="btn btn--primary btn--sm" onclick="Psycheros.newConversation()">+ New</button>
   </div>
-  <nav class="conv-list" id="conv-list" hx-get="/fragments/conv-list" hx-trigger="load" hx-swap="innerHTML">
+  <nav class="conv-list" id="conv-list" hx-get="/fragments/conv-list" hx-trigger="load, refresh-conv-list" hx-swap="innerHTML">
     ${renderConversationList(conversations)}
   </nav>
   <div class="sidebar-footer">

--- a/packages/psycheros/web/js/psycheros.js
+++ b/packages/psycheros/web/js/psycheros.js
@@ -867,7 +867,7 @@ async function newConversation() {
     }
 
     // Reload conversation list
-    htmx.trigger('#conv-list', 'load');
+    htmx.trigger('#conv-list', 'refresh-conv-list');
 
     // Clear context inspector state — new conversation has no snapshots yet
     contextSnapshots = [];
@@ -1206,7 +1206,7 @@ async function sendMessage() {
       });
       const conversation = await response.json();
       currentConversationId = conversation.id;
-      htmx.trigger('#conv-list', 'load');
+      htmx.trigger('#conv-list', 'refresh-conv-list');
       history.pushState({}, '', `/c/${conversation.id}`);
     } catch (_error) {
       showToast('Failed to create conversation');


### PR DESCRIPTION
## Summary

Fixes new conversations not appearing in the sidebar until a full app restart. The #conv-list element used hx-trigger="load", which fires once on initial render and cannot be re-triggered. The existing code called htmx.trigger('#conv-list', 'load') after creating a conversation, which was a silent no-op since 'load' has no persistent listener. Added a second trigger name (refresh-conv-list) that can actually be fired manually, and updated both call sites to use it.

## Affected packages

- [x] `packages/psycheros`
- [ ] `packages/entity-core`
- [ ] `packages/entity-loom`
- [ ] `packages/launcher`
- [ ] Workspace root / CI / docs

## Checklist

- [ ] `deno check` passes for the affected entry points
- [x] `deno lint` passes (templates.ts checked clean; web/js/ is excluded from lint by this repo's own deno.json)
- [x] `deno fmt --check` passes (templates.ts checked clean; web/js/ is excluded from fmt by this repo's own deno.json)
- [x] First-person convention preserved in any new prompts / comments / docs (no new prompts or comments were added)
- [ ] If a behavior changed, the relevant `docs/` or `CLAUDE.md` is updated
- [x] If a new external dependency was added, it's justified in the description (none was added)

`deno check` could not be verified locally. It attempted to resolve type definitions from jsr.io and download a native binary, and neither was reachable in my environment. The change itself is limited to a string literal in an HTML template and two function-call arguments, so it's unlikely to affect type checking, but this was not confirmed directly.

## Related issues

N/A — found while debugging locally, not filed as a separate issue first.