### PR TITLE
Make plugin updates compatibility-safe

### DIFF
--- a/packages/plugin-api/src/mod.ts
+++ b/packages/plugin-api/src/mod.ts
@@ -43,6 +43,8 @@ export interface PluginCompatibility {
 export interface PluginUpdateMetadata {
   repoUrl?: string;
   tagPrefix?: string;
+  /** Repository-relative directory containing this plugin's plugin.json. */
+  packagePath?: string;
 }
 
 export interface PluginCapabilityCounts {
@@ -233,13 +235,50 @@ function validateUpdateMetadata(
     throw new Error("update must be an object");
   }
   const input = value as Record<string, unknown>;
+  const packagePath = optionalString(
+    input.packagePath ?? input.package_path,
+    "update.packagePath",
+  );
   return {
     repoUrl: optionalString(input.repoUrl ?? input.repo_url, "update.repoUrl"),
     tagPrefix: optionalString(
       input.tagPrefix ?? input.tag_prefix,
       "update.tagPrefix",
     ),
+    packagePath: packagePath === undefined
+      ? undefined
+      : validatePluginPackagePath(packagePath),
   };
+}
+
+/**
+ * Validate a repository-relative directory used to locate a plugin package.
+ *
+ * Repository paths always use forward slashes and never include `.` or `..`
+ * segments. Omitting update.packagePath means the repository root.
+ */
+export function validatePluginPackagePath(path: string): string {
+  requireString(path, "update.packagePath");
+  const trimmed = path.trim();
+  if (
+    trimmed.includes("\\") || trimmed.startsWith("/") ||
+    /^[A-Za-z]:/.test(trimmed) || trimmed.includes("\0") ||
+    trimmed.includes("//")
+  ) {
+    throw new Error(
+      `update.packagePath must be a repository-relative path: ${path}`,
+    );
+  }
+  const parts = trimmed.split("/");
+  if (
+    parts.length === 0 ||
+    parts.some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error(
+      `update.packagePath must be a repository-relative path: ${path}`,
+    );
+  }
+  return parts.join("/");
 }
 
 export function isSafePluginId(id: string): boolean {

--- a/packages/plugin-api/tests/manifest_test.ts
+++ b/packages/plugin-api/tests/manifest_test.ts
@@ -41,6 +41,7 @@ Deno.test("plugin manifest accepts review metadata", () => {
     update: {
       repo_url: "https://github.com/example/artifact-search",
       tag_prefix: "v",
+      package_path: "plugins/artifact-search",
     },
     dependencies: {
       "example.shared": "^1.0.0",
@@ -56,6 +57,7 @@ Deno.test("plugin manifest accepts review metadata", () => {
     "https://github.com/example/artifact-search",
   );
   assertEquals(manifest.update?.tagPrefix, "v");
+  assertEquals(manifest.update?.packagePath, "plugins/artifact-search");
   assertEquals(manifest.dependencies?.["example.shared"], "^1.0.0");
 });
 
@@ -78,6 +80,18 @@ Deno.test("plugin manifest rejects invalid review metadata", () => {
     validatePluginManifest({
       ...base,
       update: { repo_url: 5 },
+    }, "artifact-search")
+  );
+  assertThrows(() =>
+    validatePluginManifest({
+      ...base,
+      update: { packagePath: "../artifact-search" },
+    }, "artifact-search")
+  );
+  assertThrows(() =>
+    validatePluginManifest({
+      ...base,
+      update: { packagePath: 5 },
     }, "artifact-search")
   );
   assertThrows(() =>

--- a/packages/psycheros/CHANGELOG.md
+++ b/packages/psycheros/CHANGELOG.md
@@ -6,6 +6,18 @@ follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Compatibility-safe plugin updates from monorepos:** plugin manifests can
+  declare `update.packagePath` when their package lives below the repository
+  root, and the Git install form accepts the same optional directory. Update
+  checks inspect tagged manifests from newest to oldest, skip releases whose id,
+  manifest version, or Psycheros/entity-core compatibility is invalid, and
+  select the newest compatible version. Apply now re-reads trusted update
+  metadata from the installed plugin, refuses tagged manifests that silently
+  change that update channel, and repeats every compatibility check before the
+  existing backup-and-atomic-replace flow.
+
 ## [0.9.2] - 2026-07-19
 
 ### Changed

--- a/packages/psycheros/docs/plugins.md
+++ b/packages/psycheros/docs/plugins.md
@@ -196,9 +196,13 @@ apply them with one click. v1 supports public GitHub repositories only.
 
 ```json
 {
+  "compatibility": {
+    "psycheros": ">=0.9.2 <0.10.0"
+  },
   "update": {
-    "repoUrl": "https://github.com/your-name/your-plugin",
-    "tagPrefix": "v"
+    "repoUrl": "https://github.com/your-name/community-addons",
+    "tagPrefix": "artifact-search-v",
+    "packagePath": "plugins/artifact-search"
   }
 }
 ```
@@ -209,14 +213,29 @@ apply them with one click. v1 supports public GitHub repositories only.
 - `tagPrefix` strips a fixed prefix from each tag before parsing as semver. Use
   `"v"` if you tag releases as `v1.2.3`; omit it if you tag as `1.2.3`. Tags
   that don't parse as semver after stripping are skipped silently.
+- `packagePath` optionally names the repository-relative directory containing
+  this plugin's `plugin.json`. Omit it for a standalone plugin repository whose
+  manifest is at the root. This lets one public repository publish several
+  independently tagged plugins.
 
-The check hits GitHub's public tag API (`/repos/{owner}/{repo}/tags`) once per
-plugin per click, so it's subject to GitHub's unauthenticated rate limit
-(60/hour per IP). The check response surfaces the reset time when GitHub
-returns 429. Applying an update uses the same backup → atomic replace path as a
-fresh install — the current version is moved to
-`<dataRoot>/.psycheros/plugin-backups/<id>-<timestamp>/` before the new version
-lands, and a restart is required for the new code to load.
+One-click releases must declare `compatibility.psycheros` using `@std/semver`
+range syntax, and the version in their tagged `plugin.json` must match the
+semver portion of the tag. The update check examines newer tags from highest to
+lowest and selects the first release whose manifest id, version, and host
+compatibility are valid. Newer incompatible or malformed releases are skipped
+and reported in the UI. The tagged manifest must also preserve `repoUrl`,
+`tagPrefix`, and `packagePath`; changing the trusted update channel requires a
+reviewed manual reinstall. The apply endpoint reads the repository metadata from
+the installed manifest and rechecks all of those conditions before replacement,
+so a stale or modified browser request cannot bypass the compatibility gate.
+
+The check uses GitHub's public tags and contents APIs, so it is subject to
+GitHub's unauthenticated rate limit (60/hour per IP). It makes one tag request
+plus one manifest request per newer candidate until it finds a compatible
+release; the UI surfaces rate-limit failures. Applying an update uses the same
+backup → atomic replace path as a fresh install — the current version is moved
+to `<dataRoot>/.psycheros/plugin-backups/<id>-<timestamp>/` before the new
+version lands, and a restart is required for the new code to load.
 
 ## Psycheros Entrypoint
 

--- a/packages/psycheros/docs/ui-features.md
+++ b/packages/psycheros/docs/ui-features.md
@@ -1245,7 +1245,8 @@ sidebar. Renders five regions inside the standard `.settings-view` shell:
    counts (active / degraded / pending-restart / disabled) + last-turn
    prompt-hook budget meter from `getLastBudgetReport()` + denied env vars
    across all plugins.
-3. **Install Plugin** — zip upload + git URL/ref forms. Both feed
+3. **Install Plugin** — zip upload + git URL/ref/optional-package-path forms.
+   The package path locates a plugin directory inside a monorepo. Both feed
    `handleInspectPluginZip` / `handleInspectPluginGit`, which stage a draft and
    return a preview that `renderPluginInstallReview` renders into
    `#plugin-manager-review`.
@@ -1257,8 +1258,11 @@ sidebar. Renders five regions inside the standard `.settings-view` shell:
    one-line-per-event text format the file uses), and Download log (direct link
    to `GET .../<id>/log` with `Content-Disposition:
    attachment`). Check for
-   updates calls `POST .../check-update`, renders result inline; when an update
-   is available, an apply button calls `POST .../<id>/update`.
+   updates calls `POST .../check-update`, selects the newest tagged release
+   compatible with this installation, and renders skipped incompatible releases
+   inline. When an update is available, an apply button calls
+   `POST .../<id>/update`; the server revalidates source, id, version, and
+   compatibility before replacing the existing plugin.
 5. **Loose custom tools** — unmanaged `.psycheros/custom-tools/*.js` files
    surfaced for migration awareness. The custom-tools system predates the plugin
    surface and is unchanged.

--- a/packages/psycheros/src/plugins/installer.ts
+++ b/packages/psycheros/src/plugins/installer.ts
@@ -5,6 +5,7 @@
 import JSZip from "jszip";
 import { ensureDir } from "@std/fs";
 import { basename, dirname, isAbsolute, join, relative } from "@std/path";
+import * as semver from "@std/semver";
 import { VERSION_BASE as PSYCHEROS_VERSION } from "../version.ts";
 import entityCoreDeno from "../../../entity-core/deno.json" with {
   type: "json",
@@ -18,11 +19,17 @@ import {
   type PluginStatus,
   validatePluginDirectory,
   validatePluginManifest,
+  validatePluginPackagePath,
 } from "../../../plugin-api/src/mod.ts";
 
 export type PluginInstallSource =
   | { type: "zip"; fileName?: string }
-  | { type: "git"; repoUrl: string; ref?: string };
+  | {
+    type: "git";
+    repoUrl: string;
+    ref?: string;
+    packagePath?: string;
+  };
 
 export interface PluginInstallExisting {
   name: string;
@@ -196,58 +203,15 @@ function deriveDeclaredCapabilities(
   };
 }
 
-function parseVersion(version: string): number[] | null {
-  const match = version.trim().match(/^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
-  if (!match) return null;
-  return [
-    Number(match[1]),
-    Number(match[2] ?? "0"),
-    Number(match[3] ?? "0"),
-  ];
-}
-
-function compareVersions(actual: string, expected: string): number | null {
-  const left = parseVersion(actual);
-  const right = parseVersion(expected);
-  if (!left || !right) return null;
-  for (let i = 0; i < 3; i++) {
-    if (left[i] > right[i]) return 1;
-    if (left[i] < right[i]) return -1;
-  }
-  return 0;
-}
-
-function satisfiesComparator(
-  actual: string,
-  comparator: string,
-): boolean | null {
-  const match = comparator.match(/^(>=|<=|>|<|=)?\s*v?(\d+(?:\.\d+){0,2})$/);
-  if (!match) return null;
-  const comparison = compareVersions(actual, match[2]);
-  if (comparison === null) return null;
-  switch (match[1] ?? "=") {
-    case ">=":
-      return comparison >= 0;
-    case "<=":
-      return comparison <= 0;
-    case ">":
-      return comparison > 0;
-    case "<":
-      return comparison < 0;
-    default:
-      return comparison === 0;
-  }
-}
-
 function satisfiesRange(actual: string, range: string): boolean | null {
-  const comparators = range.trim().split(/\s+/).filter(Boolean);
-  if (comparators.length === 0) return true;
-  for (const comparator of comparators) {
-    const satisfied = satisfiesComparator(actual, comparator);
-    if (satisfied === null) return null;
-    if (!satisfied) return false;
+  try {
+    return semver.satisfies(
+      semver.parse(actual),
+      semver.parseRange(range),
+    );
+  } catch {
+    return null;
   }
-  return true;
 }
 
 function compatibilityWarnings(manifest: PluginManifest): string[] {
@@ -277,6 +241,45 @@ function compatibilityWarnings(manifest: PluginManifest): string[] {
     );
   }
   return warnings;
+}
+
+/**
+ * Compatibility problems that make an unattended/one-click update unsafe.
+ *
+ * Manual installs retain the existing review-and-warning flow. Updates are
+ * stricter: a Psycheros range must be declared, and every host range that can
+ * be checked from inside Psycheros must parse and match. Launcher ranges remain
+ * informational because the daemon cannot determine the launcher version.
+ */
+export function pluginUpdateCompatibilityBlockers(
+  manifest: PluginManifest,
+): string[] {
+  const compatibility = manifest.compatibility;
+  if (!compatibility?.psycheros) {
+    return [
+      "This release does not declare compatibility.psycheros, so a safe automatic update cannot be verified.",
+    ];
+  }
+
+  const checks: Array<[string, string, string | undefined]> = [
+    ["Psycheros", PSYCHEROS_VERSION, compatibility.psycheros],
+    ["entity-core", ENTITY_CORE_VERSION, compatibility.entityCore],
+  ];
+  const blockers: string[] = [];
+  for (const [label, actual, range] of checks) {
+    if (!range) continue;
+    const satisfied = satisfiesRange(actual, range);
+    if (satisfied === null) {
+      blockers.push(
+        `Could not verify this release's ${label} compatibility range (${range}) against ${actual}.`,
+      );
+    } else if (!satisfied) {
+      blockers.push(
+        `This installation is running ${label} ${actual}, but the release declares ${label} compatibility ${range}.`,
+      );
+    }
+  }
+  return blockers;
 }
 
 function dependencyWarnings(manifest: PluginManifest): string[] {
@@ -393,9 +396,13 @@ export class PluginInstaller {
   async inspectGit(
     repoUrl: string,
     ref?: string,
+    packagePath?: string,
   ): Promise<PluginInstallPreview> {
     const cleanRepoUrl = repoUrl.trim();
     const cleanRef = ref?.trim() || undefined;
+    const cleanPackagePath = packagePath?.trim()
+      ? validatePluginPackagePath(packagePath)
+      : undefined;
     if (!cleanRepoUrl) fail("A Git repository URL is required.");
     if (cleanRepoUrl.startsWith("-")) {
       fail("That Git repository URL could not be used.");
@@ -419,10 +426,15 @@ export class PluginInstaller {
         const stderr = new TextDecoder().decode(result.stderr).trim();
         fail(stderr || "Could not clone that plugin repository.");
       }
-      return await this.finalizeStagedPackage(draftId, cloneRoot, {
+      const packageRoot = cleanPackagePath
+        ? join(cloneRoot, ...cleanPackagePath.split("/"))
+        : cloneRoot;
+      assertInside(cloneRoot, packageRoot);
+      return await this.finalizeStagedPackage(draftId, packageRoot, {
         type: "git",
         repoUrl: cleanRepoUrl,
         ref: cleanRef,
+        packagePath: cleanPackagePath,
       });
     } catch (error) {
       await removeIfExists(draftRoot);
@@ -469,6 +481,10 @@ export class PluginInstaller {
       backupPath,
       restartRequired: true,
     };
+  }
+
+  async discardDraft(draftId: string): Promise<void> {
+    await removeIfExists(this.resolveDraftRoot(draftId));
   }
 
   async removePlugin(id: string): Promise<PluginRemoveResult> {
@@ -698,6 +714,9 @@ export class PluginInstaller {
         type: "git",
         repoUrl: source.repoUrl,
         ref: typeof source.ref === "string" ? source.ref : undefined,
+        packagePath: typeof source.packagePath === "string"
+          ? validatePluginPackagePath(source.packagePath)
+          : undefined,
       };
     }
     fail("Could not read that plugin draft source.");

--- a/packages/psycheros/src/plugins/installer.ts
+++ b/packages/psycheros/src/plugins/installer.ts
@@ -200,6 +200,7 @@ function deriveDeclaredCapabilities(
     ...emptyPluginCapabilityCounts(),
     browserScripts: manifest.browser?.scripts?.length ?? 0,
     browserStyles: manifest.browser?.styles?.length ?? 0,
+    settings: manifest.capabilities?.settings === true ? 1 : 0,
   };
 }
 

--- a/packages/psycheros/src/plugins/updater.ts
+++ b/packages/psycheros/src/plugins/updater.ts
@@ -2,9 +2,11 @@
  * Plugin update checker + applier.
  *
  * The update surface piggybacks on PluginInstaller's existing inspectGit →
- * installDraft pipeline. This module is just the GitHub tag-API glue:
+ * installDraft pipeline. This module is the GitHub tag-API glue and
+ * compatibility gate:
  *   - parse owner/repo from a plugin's `update.repoUrl`
- *   - fetch that repo's tags, filter by `update.tagPrefix`, pick the highest semver
+ *   - fetch matching semver tags and inspect each tagged plugin manifest
+ *   - select the newest release compatible with this Psycheros installation
  *   - compare against the installed version
  *   - when applying, hand off to inspectGit + installDraft (which already
  *     handle backup, validation, atomic replace, restartRequired surfacing)
@@ -17,7 +19,21 @@
 
 import * as semver from "@std/semver";
 import { join } from "@std/path";
-import type { PluginInstaller } from "./installer.ts";
+import {
+  type PluginManifest,
+  type PluginUpdateMetadata,
+  validatePluginManifest,
+} from "../../../plugin-api/src/mod.ts";
+import {
+  type PluginInstaller,
+  pluginUpdateCompatibilityBlockers,
+} from "./installer.ts";
+
+export interface SkippedPluginUpdate {
+  tag: string;
+  version: string;
+  reasons: string[];
+}
 
 /** Whether an update is available, with the details needed to apply it. */
 export interface PluginUpdateCheckResult {
@@ -27,7 +43,13 @@ export interface PluginUpdateCheckResult {
   /** Present only when an update is available. */
   latestVersion?: string;
   latestTag?: string;
+  /** Highest published semver tag, even when it is incompatible or invalid. */
+  latestPublishedVersion?: string;
   repoUrl: string;
+  packagePath?: string;
+  skippedUpdateCount?: number;
+  /** At most five newest skipped releases, for concise UI diagnostics. */
+  skippedUpdates?: SkippedPluginUpdate[];
   /** ISO timestamp of the check — for the UI to show freshness. */
   checkedAt: string;
 }
@@ -40,7 +62,9 @@ export interface PluginUpdateCheckFailure {
     | "unsupported-host" // not a GitHub URL
     | "network" // fetch failed
     | "rate-limited" // GitHub returned 403/429
-    | "no-valid-tags"; // repo has tags but none match prefix + parse as semver
+    | "no-valid-tags" // repo has tags but none match prefix + parse as semver
+    | "invalid-release" // selected tag/package is internally inconsistent
+    | "incompatible"; // selected tag does not support this installation
   message: string;
   checkedAt: string;
 }
@@ -48,10 +72,11 @@ export interface PluginUpdateCheckFailure {
 export interface InstalledPluginSummary {
   id: string;
   version: string;
-  update?: {
-    repoUrl?: string;
-    tagPrefix?: string;
-  };
+  update?: PluginUpdateMetadata;
+}
+
+export interface PluginUpdateCheckOptions {
+  fetch?: typeof fetch;
 }
 
 /**
@@ -65,10 +90,11 @@ export async function readInstalledPluginSummary(
 ): Promise<InstalledPluginSummary> {
   const manifestPath = join(pluginRoot, pluginId, "plugin.json");
   const raw = JSON.parse(await Deno.readTextFile(manifestPath));
+  const manifest = validatePluginManifest(raw, pluginId);
   return {
-    id: raw.id,
-    version: raw.version,
-    update: raw.update,
+    id: manifest.id,
+    version: manifest.version,
+    update: manifest.update,
   };
 }
 
@@ -98,16 +124,17 @@ export function parseGitHubOwnerRepo(
   return undefined;
 }
 
-interface GitHubTag {
+export interface GitHubTag {
   name: string;
 }
 
 async function fetchGitHubTags(
   owner: string,
   repo: string,
+  fetchImpl: typeof fetch,
 ): Promise<GitHubTag[]> {
   const url = `https://api.github.com/repos/${owner}/${repo}/tags?per_page=100`;
-  const response = await fetch(url, {
+  const response = await fetchImpl(url, {
     headers: {
       "Accept": "application/vnd.github+json",
       "User-Agent": "psycheros-plugin-updater",
@@ -141,6 +168,70 @@ async function fetchGitHubTags(
   return await response.json() as GitHubTag[];
 }
 
+function githubContentPath(packagePath?: string): string {
+  return [...(packagePath?.split("/") ?? []), "plugin.json"]
+    .map(encodeURIComponent)
+    .join("/");
+}
+
+function decodeBase64Utf8(content: string): string {
+  const binary = atob(content.replace(/\s/g, ""));
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+async function fetchGitHubPluginManifest(
+  owner: string,
+  repo: string,
+  tag: string,
+  packagePath: string | undefined,
+  fetchImpl: typeof fetch,
+): Promise<PluginManifest> {
+  const manifestPath = githubContentPath(packagePath);
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${
+    encodeURIComponent(repo)
+  }/contents/${manifestPath}?ref=${encodeURIComponent(tag)}`;
+  const response = await fetchImpl(url, {
+    headers: {
+      "Accept": "application/vnd.github+json",
+      "User-Agent": "psycheros-plugin-updater",
+    },
+  });
+  if (response.status === 403 || response.status === 429) {
+    throw new UpdateCheckError(
+      "rate-limited",
+      "GitHub API rate limit hit while checking tagged plugin manifests. Try again later.",
+    );
+  }
+  if (response.status === 404) {
+    throw new Error(`${manifestPath} was not found at tag ${tag}.`);
+  }
+  if (!response.ok) {
+    throw new UpdateCheckError(
+      "network",
+      `GitHub returned ${response.status} ${response.statusText} while reading ${manifestPath} at ${tag}.`,
+    );
+  }
+
+  const body = await response.json() as {
+    type?: string;
+    encoding?: string;
+    content?: string;
+  };
+  if (
+    body.type !== "file" || body.encoding !== "base64" ||
+    typeof body.content !== "string"
+  ) {
+    throw new Error(`${manifestPath} at tag ${tag} was not a readable file.`);
+  }
+  const raw = JSON.parse(decodeBase64Utf8(body.content)) as unknown;
+  const candidateId = raw && typeof raw === "object" && !Array.isArray(raw) &&
+      typeof (raw as Record<string, unknown>).id === "string"
+    ? (raw as Record<string, unknown>).id as string
+    : "";
+  return validatePluginManifest(raw, candidateId);
+}
+
 /** Custom error class so the caller can branch on `reason` without string-matching. */
 export class UpdateCheckError extends Error {
   constructor(
@@ -160,7 +251,15 @@ export function findLatestTag(
   tags: GitHubTag[],
   tagPrefix?: string,
 ): { tag: string; version: semver.SemVer } | undefined {
-  let best: { tag: string; version: semver.SemVer } | undefined;
+  return findVersionTags(tags, tagPrefix)[0];
+}
+
+/** Matching semver tags sorted newest first. */
+export function findVersionTags(
+  tags: GitHubTag[],
+  tagPrefix?: string,
+): Array<{ tag: string; version: semver.SemVer }> {
+  const versions: Array<{ tag: string; version: semver.SemVer }> = [];
   for (const { name } of tags) {
     if (tagPrefix && !name.startsWith(tagPrefix)) continue;
     const versionPart = tagPrefix ? name.slice(tagPrefix.length) : name;
@@ -170,11 +269,65 @@ export function findLatestTag(
     } catch {
       continue; // tag isn't a version tag, skip silently
     }
-    if (!best || semver.greaterThan(parsed, best.version)) {
-      best = { tag: name, version: parsed };
+    versions.push({ tag: name, version: parsed });
+  }
+  return versions.sort((left, right) =>
+    semver.greaterThan(left.version, right.version)
+      ? -1
+      : semver.greaterThan(right.version, left.version)
+      ? 1
+      : 0
+  );
+}
+
+function parseTagVersion(
+  tag: string,
+  tagPrefix?: string,
+): semver.SemVer | undefined {
+  if (tagPrefix && !tag.startsWith(tagPrefix)) return undefined;
+  try {
+    return semver.parse(tagPrefix ? tag.slice(tagPrefix.length) : tag);
+  } catch {
+    return undefined;
+  }
+}
+
+function parsedVersion(version: string): semver.SemVer | undefined {
+  try {
+    return semver.parse(version);
+  } catch {
+    return undefined;
+  }
+}
+
+function sameVersion(left: semver.SemVer, right: semver.SemVer): boolean {
+  return semver.format(left) === semver.format(right);
+}
+
+function updateChannelBlockers(
+  manifest: PluginManifest,
+  installed: PluginUpdateMetadata,
+): string[] {
+  const candidate = manifest.update;
+  if (!candidate?.repoUrl) {
+    return [
+      "The tagged manifest removes update.repoUrl, which would disable future one-click updates.",
+    ];
+  }
+  const blockers: string[] = [];
+  const fields: Array<keyof PluginUpdateMetadata> = [
+    "repoUrl",
+    "tagPrefix",
+    "packagePath",
+  ];
+  for (const field of fields) {
+    if ((candidate[field] ?? "") !== (installed[field] ?? "")) {
+      blockers.push(
+        `The tagged manifest changes update.${field}; update channels can only be changed by a reviewed manual reinstall.`,
+      );
     }
   }
-  return best;
+  return blockers;
 }
 
 /**
@@ -186,8 +339,10 @@ export function findLatestTag(
 export async function checkPluginUpdate(
   pluginRoot: string,
   pluginId: string,
+  options: PluginUpdateCheckOptions = {},
 ): Promise<PluginUpdateCheckResult | PluginUpdateCheckFailure> {
   const checkedAt = new Date().toISOString();
+  const fetchImpl = options.fetch ?? fetch;
   let summary: InstalledPluginSummary;
   try {
     summary = await readInstalledPluginSummary(pluginRoot, pluginId);
@@ -224,7 +379,7 @@ export async function checkPluginUpdate(
 
   let tags: GitHubTag[];
   try {
-    tags = await fetchGitHubTags(ownerRepo.owner, ownerRepo.repo);
+    tags = await fetchGitHubTags(ownerRepo.owner, ownerRepo.repo, fetchImpl);
   } catch (error) {
     if (error instanceof UpdateCheckError) {
       return {
@@ -242,8 +397,8 @@ export async function checkPluginUpdate(
     };
   }
 
-  const latest = findLatestTag(tags, summary.update?.tagPrefix);
-  if (!latest) {
+  const versions = findVersionTags(tags, summary.update?.tagPrefix);
+  if (versions.length === 0) {
     return {
       pluginId,
       reason: "no-valid-tags",
@@ -255,32 +410,104 @@ export async function checkPluginUpdate(
     };
   }
 
-  let currentVersion: semver.SemVer;
-  try {
-    currentVersion = semver.parse(summary.version);
-  } catch {
-    // Installed version isn't semver-parsable (e.g., "unknown"). Treat any
-    // remote tag as an update so the operator can re-install to a known
-    // good version.
+  const currentVersion = parsedVersion(summary.version);
+  const candidates = currentVersion
+    ? versions.filter((candidate) =>
+      semver.greaterThan(candidate.version, currentVersion)
+    )
+    : versions;
+  const skippedUpdates: SkippedPluginUpdate[] = [];
+  let skippedUpdateCount = 0;
+  const recordSkipped = (
+    candidate: { tag: string; version: semver.SemVer },
+    reasons: string[],
+  ) => {
+    skippedUpdateCount += 1;
+    if (skippedUpdates.length < 5) {
+      skippedUpdates.push({
+        tag: candidate.tag,
+        version: semver.format(candidate.version),
+        reasons,
+      });
+    }
+  };
+
+  for (const candidate of candidates) {
+    let manifest: PluginManifest;
+    try {
+      manifest = await fetchGitHubPluginManifest(
+        ownerRepo.owner,
+        ownerRepo.repo,
+        candidate.tag,
+        summary.update?.packagePath,
+        fetchImpl,
+      );
+    } catch (error) {
+      if (error instanceof UpdateCheckError) {
+        return {
+          pluginId,
+          reason: error.reason,
+          message: error.message,
+          checkedAt,
+        };
+      }
+      recordSkipped(candidate, [
+        `Could not validate the tagged plugin manifest: ${
+          (error as Error).message
+        }`,
+      ]);
+      continue;
+    }
+
+    const reasons: string[] = [];
+    if (manifest.id !== pluginId) {
+      reasons.push(
+        `The tagged manifest id "${manifest.id}" does not match installed plugin id "${pluginId}".`,
+      );
+    }
+    const manifestVersion = parsedVersion(manifest.version);
+    if (!manifestVersion || !sameVersion(manifestVersion, candidate.version)) {
+      reasons.push(
+        `The tagged manifest version "${manifest.version}" does not match tag version ${
+          semver.format(candidate.version)
+        }.`,
+      );
+    }
+    reasons.push(...updateChannelBlockers(manifest, summary.update!));
+    reasons.push(...pluginUpdateCompatibilityBlockers(manifest));
+    if (reasons.length > 0) {
+      recordSkipped(candidate, reasons);
+      continue;
+    }
+
     return {
       pluginId,
       currentVersion: summary.version,
       updateAvailable: true,
-      latestVersion: semver.format(latest.version),
-      latestTag: latest.tag,
+      latestVersion: semver.format(candidate.version),
+      latestTag: candidate.tag,
+      latestPublishedVersion: semver.format(versions[0].version),
       repoUrl,
+      packagePath: summary.update?.packagePath,
+      skippedUpdateCount: skippedUpdateCount || undefined,
+      skippedUpdates: skippedUpdates.length > 0 ? skippedUpdates : undefined,
       checkedAt,
     };
   }
 
-  const isUpdate = semver.greaterThan(latest.version, currentVersion);
   return {
     pluginId,
     currentVersion: summary.version,
-    updateAvailable: isUpdate,
-    latestVersion: semver.format(latest.version),
-    latestTag: latest.tag,
+    updateAvailable: false,
+    latestVersion: skippedUpdateCount === 0
+      ? semver.format(versions[0].version)
+      : undefined,
+    latestTag: skippedUpdateCount === 0 ? versions[0].tag : undefined,
+    latestPublishedVersion: semver.format(versions[0].version),
     repoUrl,
+    packagePath: summary.update?.packagePath,
+    skippedUpdateCount: skippedUpdateCount || undefined,
+    skippedUpdates: skippedUpdates.length > 0 ? skippedUpdates : undefined,
     checkedAt,
   };
 }
@@ -295,15 +522,72 @@ export async function applyPluginUpdate(
   installer: PluginInstaller,
   pluginId: string,
   latestTag: string,
-  repoUrl: string,
 ): Promise<{ backupPath?: string }> {
-  const preview = await installer.inspectGit(repoUrl, latestTag);
-  if (preview.manifest.id !== pluginId) {
+  const summary = await readInstalledPluginSummary(
+    installer.pluginRoot,
+    pluginId,
+  );
+  const repoUrl = summary.update?.repoUrl;
+  if (!repoUrl) {
     throw new UpdateCheckError(
-      "network",
-      `Update target's id "${preview.manifest.id}" does not match installed plugin id "${pluginId}". Aborting before replace.`,
+      "invalid-release",
+      "The installed plugin does not declare update.repoUrl.",
     );
   }
-  const result = await installer.installDraft(preview.draftId);
-  return { backupPath: result.backupPath };
+  const tagVersion = parseTagVersion(latestTag, summary.update?.tagPrefix);
+  if (!tagVersion) {
+    throw new UpdateCheckError(
+      "invalid-release",
+      `Update tag "${latestTag}" does not match this plugin's tagPrefix or semver format.`,
+    );
+  }
+  const currentVersion = parsedVersion(summary.version);
+  if (currentVersion && !semver.greaterThan(tagVersion, currentVersion)) {
+    throw new UpdateCheckError(
+      "invalid-release",
+      `Update version ${
+        semver.format(tagVersion)
+      } is not newer than installed version ${summary.version}.`,
+    );
+  }
+
+  const preview = await installer.inspectGit(
+    repoUrl,
+    latestTag,
+    summary.update?.packagePath,
+  );
+  try {
+    if (preview.manifest.id !== pluginId) {
+      throw new UpdateCheckError(
+        "invalid-release",
+        `Update target's id "${preview.manifest.id}" does not match installed plugin id "${pluginId}". Aborting before replace.`,
+      );
+    }
+    const manifestVersion = parsedVersion(preview.manifest.version);
+    if (!manifestVersion || !sameVersion(manifestVersion, tagVersion)) {
+      throw new UpdateCheckError(
+        "invalid-release",
+        `Update target's manifest version "${preview.manifest.version}" does not match tag version ${
+          semver.format(tagVersion)
+        }. Aborting before replace.`,
+      );
+    }
+    const blockers = [
+      ...updateChannelBlockers(preview.manifest, summary.update!),
+      ...pluginUpdateCompatibilityBlockers(preview.manifest),
+    ];
+    if (blockers.length > 0) {
+      throw new UpdateCheckError(
+        "incompatible",
+        `Update ${
+          semver.format(tagVersion)
+        } is not compatible with this installation: ${blockers.join(" ")}`,
+      );
+    }
+    const result = await installer.installDraft(preview.draftId);
+    return { backupPath: result.backupPath };
+  } catch (error) {
+    await installer.discardDraft(preview.draftId);
+    throw error;
+  }
 }

--- a/packages/psycheros/src/server/plugin-manager-routes.ts
+++ b/packages/psycheros/src/server/plugin-manager-routes.ts
@@ -75,7 +75,10 @@ export async function handleInspectPluginGit(
     const body = await readJsonObject(request);
     const repoUrl = typeof body.repoUrl === "string" ? body.repoUrl : "";
     const ref = typeof body.ref === "string" ? body.ref : undefined;
-    const preview = await installer.inspectGit(repoUrl, ref);
+    const packagePath = typeof body.packagePath === "string"
+      ? body.packagePath
+      : undefined;
+    const preview = await installer.inspectGit(repoUrl, ref, packagePath);
     return json({ success: true, preview });
   } catch (error) {
     return errorResponse(error);
@@ -233,12 +236,11 @@ export async function handlePluginCheckUpdate(
 }
 
 /**
- * Apply a previously-checked update. Body: `{ tag, repoUrl }` — both come
- * straight from the prior check-update response, so the UI just hands them
- * back. Hands off to PluginInstaller which handles backup + atomic replace
- * + restartRequired. Refuses if the update target's manifest id doesn't
- * match the installed plugin id — defends against a tag pointing at a
- * renamed/forked repo.
+ * Apply a previously-checked update. Body: `{ tag }`. The repository,
+ * tag prefix, and optional package path are read again from the installed
+ * manifest rather than trusted from the browser. PluginInstaller handles
+ * backup + atomic replace + restartRequired; the updater revalidates id,
+ * version, and host compatibility before replacement.
  */
 export async function handlePluginApplyUpdate(
   installer: PluginInstaller,
@@ -251,14 +253,14 @@ export async function handlePluginApplyUpdate(
     if (!body || typeof body !== "object") {
       return json({ success: false, error: "Request body required." }, 400);
     }
-    const { tag, repoUrl } = body as { tag?: string; repoUrl?: string };
-    if (typeof tag !== "string" || typeof repoUrl !== "string") {
+    const { tag } = body as { tag?: string };
+    if (typeof tag !== "string") {
       return json({
         success: false,
-        error: "Body must include 'tag' and 'repoUrl'.",
+        error: "Body must include 'tag'.",
       }, 400);
     }
-    const result = await applyPluginUpdate(installer, pluginId, tag, repoUrl);
+    const result = await applyPluginUpdate(installer, pluginId, tag);
     return json({
       success: true,
       pluginId,

--- a/packages/psycheros/src/server/templates.ts
+++ b/packages/psycheros/src/server/templates.ts
@@ -887,6 +887,9 @@ function renderPluginUpdate(status: PluginStatus): string {
   const values = [
     status.update.repoUrl ? `repo ${status.update.repoUrl}` : "",
     status.update.tagPrefix ? `tag prefix ${status.update.tagPrefix}` : "",
+    status.update.packagePath
+      ? `package path ${status.update.packagePath}`
+      : "",
   ].filter(Boolean).join(", ");
   return `<p class="settings-note">Update metadata: ${
     escapeHtml(values || "declared")
@@ -1062,6 +1065,10 @@ export function renderPluginsSettings(
             <div class="llm-field" style="min-width:160px;">
               <label for="plugin-git-ref">Branch or tag</label>
               <input type="text" id="plugin-git-ref" class="input-field llm-input" placeholder="default">
+            </div>
+            <div class="llm-field" style="min-width:220px;">
+              <label for="plugin-git-package-path">Plugin directory (optional)</label>
+              <input type="text" id="plugin-git-package-path" class="input-field llm-input" placeholder="plugins/my-plugin">
             </div>
             <button type="submit" class="btn btn--primary">Inspect Git</button>
           </form>

--- a/packages/psycheros/tests/plugin_installer_test.ts
+++ b/packages/psycheros/tests/plugin_installer_test.ts
@@ -58,7 +58,11 @@ Deno.test("plugin installer stages singleton zip packages and installs drafts", 
   const dataRoot = await Deno.makeTempDir({ prefix: "psycheros-plugin-ui-" });
   const installer = new PluginInstaller(dataRoot);
   const bytes = await zipPackage({
-    "wrapped/plugin.json": JSON.stringify(pluginManifest("wrapped-plugin")),
+    "wrapped/plugin.json": JSON.stringify(
+      pluginManifest("wrapped-plugin", {
+        capabilities: { settings: true },
+      }),
+    ),
     "wrapped/psycheros.ts": "export default {};",
   });
 
@@ -66,6 +70,7 @@ Deno.test("plugin installer stages singleton zip packages and installs drafts", 
   assertEquals(preview.manifest.id, "wrapped-plugin");
   assertEquals(preview.source.type, "zip");
   assertEquals(preview.restartRequired, true);
+  assertEquals(preview.capabilities.settings, 1);
   assertStringIncludes(preview.warnings.join("\n"), "dependencies");
   assert(
     await Deno.stat(

--- a/packages/psycheros/tests/updater_test.ts
+++ b/packages/psycheros/tests/updater_test.ts
@@ -1,6 +1,56 @@
-import { assertEquals, assertExists } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import { join } from "@std/path";
 import * as semver from "@std/semver";
-import { findLatestTag, parseGitHubOwnerRepo } from "../src/plugins/updater.ts";
+import {
+  applyPluginUpdate,
+  checkPluginUpdate,
+  findLatestTag,
+  parseGitHubOwnerRepo,
+  UpdateCheckError,
+} from "../src/plugins/updater.ts";
+import { PluginInstaller } from "../src/plugins/installer.ts";
+
+function updateManifest(
+  id: string,
+  version: string,
+  compatibility: string | undefined,
+  update: Record<string, string>,
+): Record<string, unknown> {
+  return {
+    id,
+    name: id,
+    version,
+    apiVersion: 1,
+    compatibility: compatibility ? { psycheros: compatibility } : undefined,
+    update,
+    entrypoints: { psycheros: "./psycheros.ts" },
+  };
+}
+
+function githubFileResponse(value: unknown): Response {
+  return Response.json({
+    type: "file",
+    encoding: "base64",
+    content: btoa(JSON.stringify(value)),
+  });
+}
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+  const result = await new Deno.Command("git", {
+    cwd,
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  if (!result.success) {
+    throw new Error(new TextDecoder().decode(result.stderr));
+  }
+}
 
 Deno.test("parseGitHubOwnerRepo accepts the common GitHub URL shapes", () => {
   // Canonical https.
@@ -99,4 +149,193 @@ Deno.test("findLatestTag handles a mix of valid semver and junk tags", () => {
   ]);
   assertExists(result);
   assertEquals(result.tag, "2.0.0");
+});
+
+Deno.test("update check selects the newest compatible package in a monorepo", async () => {
+  const pluginRoot = await Deno.makeTempDir({
+    prefix: "psycheros-update-check-",
+  });
+  const pluginId = "community-test";
+  const packagePath = "plugins/community-test";
+  const update = {
+    repoUrl: "https://github.com/example/community-addons",
+    tagPrefix: "community-test-v",
+    packagePath,
+  };
+  await Deno.mkdir(join(pluginRoot, pluginId));
+  await Deno.writeTextFile(
+    join(pluginRoot, pluginId, "plugin.json"),
+    JSON.stringify(updateManifest(pluginId, "1.0.0", ">=0.9.0 <1.0.0", update)),
+  );
+
+  const requested: string[] = [];
+  const mockFetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    requested.push(url);
+    if (url.endsWith("/tags?per_page=100")) {
+      return Response.json([
+        { name: "community-test-v3.0.0" },
+        { name: "community-test-v2.0.0" },
+        { name: "community-test-v1.2.0" },
+        { name: "community-test-v1.0.0" },
+      ]);
+    }
+    if (url.includes("ref=community-test-v3.0.0")) {
+      return githubFileResponse(
+        updateManifest(pluginId, "3.0.0", "^0.9.0", {
+          ...update,
+          repoUrl: "https://github.com/example/hijacked-channel",
+        }),
+      );
+    }
+    if (url.includes("ref=community-test-v2.0.0")) {
+      return githubFileResponse(
+        updateManifest(pluginId, "2.0.0", ">=2.0.0", update),
+      );
+    }
+    if (url.includes("ref=community-test-v1.2.0")) {
+      return githubFileResponse(
+        updateManifest(pluginId, "1.2.0", "^0.9.0", update),
+      );
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+
+  const result = await checkPluginUpdate(pluginRoot, pluginId, {
+    fetch: mockFetch,
+  });
+  if ("reason" in result) {
+    throw new Error(result.message);
+  }
+  assertEquals(result.updateAvailable, true);
+  assertEquals(result.latestVersion, "1.2.0");
+  assertEquals(result.latestPublishedVersion, "3.0.0");
+  assertEquals(result.skippedUpdateCount, 2);
+  assertEquals(result.skippedUpdates?.[0].version, "3.0.0");
+  assertStringIncludes(
+    result.skippedUpdates?.[0].reasons[0] ?? "",
+    "changes update.repoUrl",
+  );
+  assertEquals(result.skippedUpdates?.[1].version, "2.0.0");
+  assertStringIncludes(
+    result.skippedUpdates?.[1].reasons[0] ?? "",
+    "declares Psycheros compatibility >=2.0.0",
+  );
+  assertEquals(result.packagePath, packagePath);
+  assertEquals(
+    requested.some((url) =>
+      url.includes(
+        "/contents/plugins/community-test/plugin.json?ref=community-test-v1.2.0",
+      )
+    ),
+    true,
+  );
+});
+
+Deno.test("update apply rejects incompatible tags then atomically updates a monorepo plugin", async () => {
+  const root = await Deno.makeTempDir({ prefix: "psycheros-update-apply-" });
+  const repo = join(root, "community-addons");
+  const packageDirectory = join(repo, "plugins", "community-test");
+  const dataRoot = join(root, "data");
+  const installer = new PluginInstaller(dataRoot);
+  const pluginId = "community-test";
+  const update = {
+    repoUrl: repo,
+    tagPrefix: "community-test-v",
+    packagePath: "plugins/community-test",
+  };
+
+  await Deno.mkdir(packageDirectory, { recursive: true });
+  await runGit(repo, ["init"]);
+  await Deno.writeTextFile(
+    join(packageDirectory, "plugin.json"),
+    JSON.stringify(updateManifest(pluginId, "1.1.0", ">=0.9.0 <1.0.0", update)),
+  );
+  await Deno.writeTextFile(
+    join(packageDirectory, "psycheros.ts"),
+    "export default { version: 'compatible' };",
+  );
+  await runGit(repo, ["add", "."]);
+  await runGit(repo, [
+    "-c",
+    "user.name=Psycheros Tests",
+    "-c",
+    "user.email=tests@psycheros.local",
+    "commit",
+    "-m",
+    "compatible",
+  ]);
+  await runGit(repo, ["tag", "community-test-v1.1.0"]);
+
+  await Deno.writeTextFile(
+    join(packageDirectory, "plugin.json"),
+    JSON.stringify(updateManifest(pluginId, "2.0.0", ">=2.0.0", update)),
+  );
+  await Deno.writeTextFile(
+    join(packageDirectory, "psycheros.ts"),
+    "export default { version: 'incompatible' };",
+  );
+  await runGit(repo, ["add", "."]);
+  await runGit(repo, [
+    "-c",
+    "user.name=Psycheros Tests",
+    "-c",
+    "user.email=tests@psycheros.local",
+    "commit",
+    "-m",
+    "incompatible",
+  ]);
+  await runGit(repo, ["tag", "community-test-v2.0.0"]);
+
+  const installedDirectory = join(installer.pluginRoot, pluginId);
+  await Deno.mkdir(installedDirectory, { recursive: true });
+  await Deno.writeTextFile(
+    join(installedDirectory, "plugin.json"),
+    JSON.stringify(updateManifest(pluginId, "1.0.0", ">=0.9.0 <1.0.0", update)),
+  );
+  await Deno.writeTextFile(
+    join(installedDirectory, "psycheros.ts"),
+    "export default { version: 'installed' };",
+  );
+
+  await assertRejects(
+    () =>
+      applyPluginUpdate(
+        installer,
+        pluginId,
+        "community-test-v2.0.0",
+      ),
+    UpdateCheckError,
+    "not compatible",
+  );
+  assertEquals(
+    JSON.parse(
+      await Deno.readTextFile(join(installedDirectory, "plugin.json")),
+    ).version,
+    "1.0.0",
+  );
+  const stagedAfterRejection = [];
+  for await (const entry of Deno.readDir(installer.stagingRoot)) {
+    stagedAfterRejection.push(entry.name);
+  }
+  assertEquals(stagedAfterRejection, []);
+
+  const applied = await applyPluginUpdate(
+    installer,
+    pluginId,
+    "community-test-v1.1.0",
+  );
+  assertExists(applied.backupPath);
+  assertEquals(
+    JSON.parse(
+      await Deno.readTextFile(join(installedDirectory, "plugin.json")),
+    ).version,
+    "1.1.0",
+  );
+  assertEquals(
+    JSON.parse(
+      await Deno.readTextFile(join(applied.backupPath!, "plugin.json")),
+    ).version,
+    "1.0.0",
+  );
 });

--- a/packages/psycheros/web/js/psycheros.js
+++ b/packages/psycheros/web/js/psycheros.js
@@ -5106,7 +5106,9 @@ function pluginManagerCapabilities(capabilities) {
 function pluginManagerSourceLabel(source) {
   if (!source) return 'Unknown source';
   if (source.type === 'git') {
-    return 'Git: ' + source.repoUrl + (source.ref ? ' @ ' + source.ref : ' @ default branch');
+    return 'Git: ' + source.repoUrl +
+      (source.ref ? ' @ ' + source.ref : ' @ default branch') +
+      (source.packagePath ? ' / ' + source.packagePath : '');
   }
   return 'Zip: ' + (source.fileName || 'uploaded package');
 }
@@ -5349,6 +5351,7 @@ async function inspectPluginGit(event) {
   event.preventDefault();
   const repoUrl = document.getElementById('plugin-git-url')?.value || '';
   const ref = document.getElementById('plugin-git-ref')?.value || '';
+  const packagePath = document.getElementById('plugin-git-package-path')?.value || '';
   const button = event.submitter;
   const originalText = button ? button.textContent : '';
   if (button) {
@@ -5359,7 +5362,7 @@ async function inspectPluginGit(event) {
     const result = await pluginManagerJson('/api/plugin-manager/inspect-git', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ repoUrl, ref }),
+      body: JSON.stringify({ repoUrl, ref, packagePath }),
     });
     renderPluginInstallReview(result.preview);
   } catch (error) {
@@ -5654,23 +5657,42 @@ function renderPluginUpdateResult(pluginId, target, result) {
       'network': 'Network error',
       'rate-limited': 'Rate-limited by GitHub',
       'no-valid-tags': 'No version tags found',
+      'invalid-release': 'Invalid plugin release',
+      'incompatible': 'Incompatible plugin release',
     }[result.reason] || 'Update check failed';
     target.innerHTML =
       '<p class="settings-note"><strong>' + pluginManagerEscape(reasonLabel) +
       ':</strong> ' + pluginManagerEscape(result.message || '') + '</p>';
     return;
   }
+  const skippedCount = Number(result.skippedUpdateCount || 0);
+  const skipped = Array.isArray(result.skippedUpdates) ? result.skippedUpdates : [];
+  const newestSkipped = skipped[0];
+  const skippedDetail = newestSkipped && Array.isArray(newestSkipped.reasons) && newestSkipped.reasons[0]
+    ? ' ' + pluginManagerEscape(newestSkipped.reasons[0])
+    : '';
+  if (!result.updateAvailable && skippedCount > 0) {
+    target.innerHTML =
+      '<p class="settings-note"><strong>No compatible update found.</strong> ' +
+      pluginManagerEscape(String(skippedCount)) + ' newer release' +
+      (skippedCount === 1 ? ' was' : 's were') +
+      ' skipped for this installation.' +
+      (result.latestPublishedVersion
+        ? ' Newest published: <code>' + pluginManagerEscape(result.latestPublishedVersion) + '</code>.'
+        : '') +
+      skippedDetail + '</p>';
+    return;
+  }
   if (!result.updateAvailable) {
     target.innerHTML =
       '<p class="settings-note">Up to date at <code>' +
       pluginManagerEscape(result.currentVersion || '?') + '</code>' +
-      (result.latestVersion ? ' (latest tag: <code>' + pluginManagerEscape(result.latestVersion) + '</code>)' : '') +
+      (result.latestPublishedVersion ? ' (latest tag: <code>' + pluginManagerEscape(result.latestPublishedVersion) + '</code>)' : '') +
       '.</p>';
     return;
   }
-  // Update available — render the apply button inline. The tag + repoUrl
-  // travel through data-attrs on the button so applyPluginUpdate has what
-  // it needs without re-checking.
+  // Update available — the browser returns only the selected tag. The server
+  // re-reads repository metadata and compatibility from trusted manifests.
   target.innerHTML =
     '<div style="display:flex;gap:var(--sp-2);align-items:center;flex-wrap:wrap;">' +
       pluginManagerBadge('Update available', 'badge-primary') +
@@ -5681,14 +5703,18 @@ function renderPluginUpdateResult(pluginId, target, result) {
       '<button type="button" class="btn btn--primary btn--sm"' +
         ' data-plugin-id="' + pluginManagerEscape(pluginId) + '"' +
         ' data-tag="' + pluginManagerEscape(result.latestTag || '') + '"' +
-        ' data-repo-url="' + pluginManagerEscape(result.repoUrl || '') + '"' +
-        ' onclick="applyPluginUpdate(this.dataset.pluginId, this.dataset.tag, this.dataset.repoUrl, this)">' +
+        ' onclick="applyPluginUpdate(this.dataset.pluginId, this.dataset.tag, this)">' +
         'Update to ' + pluginManagerEscape(result.latestVersion || 'latest') +
       '</button>' +
-    '</div>';
+    '</div>' +
+    (skippedCount > 0
+      ? '<p class="settings-note" style="margin-top:var(--sp-2);">' +
+        pluginManagerEscape(String(skippedCount)) + ' newer incompatible or invalid release' +
+        (skippedCount === 1 ? ' was' : 's were') + ' skipped.' + skippedDetail + '</p>'
+      : '');
 }
 
-async function applyPluginUpdate(pluginId, tag, repoUrl, button) {
+async function applyPluginUpdate(pluginId, tag, button) {
   if (!confirm('Apply update to ' + pluginId + ' at tag ' + tag + '?\n\nThe current install will be backed up. Psycheros will need a restart for the new version to load.')) {
     return;
   }
@@ -5703,7 +5729,7 @@ async function applyPluginUpdate(pluginId, tag, repoUrl, button) {
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ tag, repoUrl }),
+        body: JSON.stringify({ tag }),
       },
     );
     showToast('Plugin updated. Restart Psycheros for the new version to take effect.');


### PR DESCRIPTION
## Why

The plugin manager currently assumes every Git plugin lives at the repository root and treats the highest matching tag as the update. That makes monorepo addons awkward to install and can offer or apply a release that does not support the running Psycheros version. The apply route also accepts repository details from the browser instead of re-reading the installed plugin's declared update channel.

## What changed

- add optional `update.packagePath` metadata for plugins stored in a repository subdirectory
- support inspecting and installing that subdirectory without copying the rest of the repository
- inspect each tagged `plugin.json` and choose the newest release compatible with the running Psycheros and Entity Core versions
- validate plugin identity, tag/manifest version agreement, compatibility ranges, and the pinned update channel again during apply
- make apply requests identify only the selected tag; repository coordinates now come from the installed manifest
- report skipped newer releases and their reasons in the addon manager UI
- document the monorepo and compatibility-safe release contract and cover it with tests

## Verification

- `deno test -A packages/plugin-api/tests/manifest_test.ts packages/psycheros/tests/updater_test.ts packages/psycheros/tests/plugin_installer_test.ts` — 26 passed
- `deno test -A --quiet packages/psycheros/tests packages/plugin-api/tests` — 156 passed
- `deno lint` on all touched TypeScript files — passed
- `deno check` on the updater and plugin-manager routes — passed
- `deno fmt --check` on all applicable touched files — passed
- isolated Psycheros 0.9.2 smoke test with a tagged local monorepo plugin:
  - installed `addons/live-smoke` v1.0.0
  - rejected incompatible v2.0.0 without changing the installation or leaving staging files
  - applied compatible v1.1.0 with a v1.0.0 backup
  - restarted cleanly with the updated plugin active

The full workspace test task reports 163 passes and 8 Windows cleanup failures in `packages/entity-core/tests/runner_test.ts` (`os error 32` while removing temporary database directories). The same failure reproduces on pristine upstream `main`, so it is not introduced by this branch. Repository-wide `fmt:check` also reports pre-existing formatting differences in unrelated launcher and Entity Loom files; all files changed here pass their targeted format check.

Draft for maintainer review before we convert and publish the first monorepo addon releases against this contract.
