### PR TITLE
fix(discord): reset ACK state for new heartbeat cycles

### DIFF
--- a/packages/psycheros/src/discord/gateway.ts
+++ b/packages/psycheros/src/discord/gateway.ts
@@ -463,6 +463,10 @@ export class DiscordGatewayClient {
 
   private startHeartbeat(intervalMs: number): void {
     this.cleanupHeartbeat();
+    // HELLO starts a fresh heartbeat cycle for this socket. A missed ACK from
+    // the socket we just replaced must not make the first timer tick close the
+    // new connection before it has sent even one heartbeat of its own.
+    this.lastHeartbeatAcked = true;
     // Discord recommends a small random jitter
     const jittered = intervalMs * (0.9 + Math.random() * 0.2);
 

--- a/packages/psycheros/tests/discord_gateway_heartbeat_test.ts
+++ b/packages/psycheros/tests/discord_gateway_heartbeat_test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "@std/assert";
+import { DiscordGatewayClient } from "../src/discord/gateway.ts";
+
+type GatewayInternals = {
+  lastHeartbeatAcked: boolean;
+  handlePayload: (
+    payload: { op: number; d?: unknown; t?: string; s?: number },
+  ) => void;
+};
+
+Deno.test("Discord gateway starts a resumed socket with a fresh heartbeat cycle", () => {
+  const client = new DiscordGatewayClient("token");
+  const internals = client as unknown as GatewayInternals;
+  internals.lastHeartbeatAcked = false;
+
+  internals.handlePayload({
+    op: 10,
+    d: { heartbeat_interval: 60_000 },
+  });
+
+  assertEquals(internals.lastHeartbeatAcked, true);
+  client.disconnect();
+});


### PR DESCRIPTION
## Summary

- reset the heartbeat ACK sentinel whenever Discord sends `HELLO` and a new heartbeat cycle begins
- prevent a missed ACK on the replaced socket from immediately closing the resumed socket before its first heartbeat
- add a focused regression test

Closes #42.

## Verification

- `deno fmt --check packages/psycheros/src/discord/gateway.ts packages/psycheros/tests/discord_gateway_heartbeat_test.ts`
- `deno check --config packages/psycheros/deno.json packages/psycheros/src/discord/gateway.ts packages/psycheros/tests/discord_gateway_heartbeat_test.ts`
- `deno test --config packages/psycheros/deno.json -A packages/psycheros/tests/discord_gateway_heartbeat_test.ts`