### PR TITLE
Fix Discord turn continuity across overlap and restarts

### DIFF
--- a/packages/psycheros/CHANGELOG.md
+++ b/packages/psycheros/CHANGELOG.md
@@ -6,6 +6,14 @@ follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Discord batches now reach an explicit contribution, deliberate-quiet, or
+  retryable-failure outcome. Eligible work survives daemon restarts in the
+  existing SQLite database, overlapping flushes resume after the active channel
+  turn, and replies or reactions cannot target message IDs that appear only in
+  older conversation history.
+
 ## [0.10.0] - 2026-07-24
 
 ### Added

--- a/packages/psycheros/src/db/schema.ts
+++ b/packages/psycheros/src/db/schema.ts
@@ -231,6 +231,34 @@ export const SCHEMA = `
 
   CREATE INDEX IF NOT EXISTS idx_context_snapshots_conversation
     ON context_snapshots(conversation_id, turn_index DESC);
+
+  -- Discord receipt work is durable until the entity reaches an explicit
+  -- outcome. In-memory debounce remains an optimization rather than the only
+  -- record that a message still needs a decision.
+  CREATE TABLE IF NOT EXISTS discord_pending_messages (
+    message_id TEXT PRIMARY KEY,
+    channel_id TEXT NOT NULL,
+    server_id TEXT,
+    is_dm INTEGER NOT NULL DEFAULT 0 CHECK (is_dm IN (0, 1)),
+    channel_mode TEXT NOT NULL CHECK (channel_mode IN ('active', 'lurk', 'strict')),
+    directly_addressed INTEGER NOT NULL DEFAULT 0 CHECK (
+      directly_addressed IN (0, 1)
+    ),
+    message_json TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending' CHECK (
+      state IN ('pending', 'processing')
+    ),
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_discord_pending_ready
+    ON discord_pending_messages(state, next_attempt_at, received_at ASC);
+
+  CREATE INDEX IF NOT EXISTS idx_discord_pending_channel
+    ON discord_pending_messages(channel_id, received_at ASC);
 `;
 
 /**

--- a/packages/psycheros/src/discord/disposition.ts
+++ b/packages/psycheros/src/discord/disposition.ts
@@ -1,0 +1,9 @@
+import type { DiscordTurnDisposition } from "./router.ts";
+
+export function classifyDiscordTurnDisposition(options: {
+  discordActionAttempted: boolean;
+  discordActionSucceeded: boolean;
+}): DiscordTurnDisposition {
+  if (!options.discordActionAttempted) return "deliberately_quiet";
+  return options.discordActionSucceeded ? "contributed" : "failed";
+}

--- a/packages/psycheros/src/discord/mod.ts
+++ b/packages/psycheros/src/discord/mod.ts
@@ -19,8 +19,13 @@ export { MessageRouter } from "./router.ts";
 export type {
   AccumulatedMessage,
   DiscordTurnContext,
+  DiscordTurnDisposition,
+  DiscordTurnOutcome,
   RouterDeps,
 } from "./router.ts";
+export { DiscordPendingStore } from "./pending-store.ts";
+export type { PendingDiscordMessage } from "./pending-store.ts";
+export { classifyDiscordTurnDisposition } from "./disposition.ts";
 
 export { ConversationMapper } from "./conversation-map.ts";
 export {

--- a/packages/psycheros/src/discord/pending-store.ts
+++ b/packages/psycheros/src/discord/pending-store.ts
@@ -1,0 +1,209 @@
+import type { Database } from "@db/sqlite";
+import type { ChannelMode } from "../llm/discord-settings.ts";
+import type { AccumulatedMessage } from "./router.ts";
+
+export interface PendingDiscordMessage {
+  channelId: string;
+  serverId: string | null;
+  isDM: boolean;
+  mode: ChannelMode;
+  directlyAddressed: boolean;
+  message: AccumulatedMessage;
+}
+
+interface PendingDiscordMessageRow {
+  message_id: string;
+  channel_id: string;
+  server_id: string | null;
+  is_dm: number;
+  channel_mode: string;
+  directly_addressed: number;
+  message_json: string;
+}
+
+const MAX_RECOVERY_BATCH = 500;
+const BASE_RETRY_DELAY_MS = 30_000;
+const MAX_RETRY_DELAY_MS = 15 * 60_000;
+
+/** A durable local inbox beneath Discord's in-memory debounce buffers. */
+export class DiscordPendingStore {
+  constructor(private readonly db: Database) {
+    this.reclaimProcessingOnStart();
+  }
+
+  enqueue(record: PendingDiscordMessage): void {
+    const now = new Date().toISOString();
+    this.db.exec(
+      `INSERT INTO discord_pending_messages (
+         message_id, channel_id, server_id, is_dm, channel_mode,
+         directly_addressed, message_json, state, attempt_count,
+         next_attempt_at, received_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?)
+       ON CONFLICT(message_id) DO UPDATE SET
+         channel_id = excluded.channel_id,
+         server_id = excluded.server_id,
+         is_dm = excluded.is_dm,
+         channel_mode = excluded.channel_mode,
+         directly_addressed = excluded.directly_addressed,
+         message_json = excluded.message_json,
+         updated_at = excluded.updated_at`,
+      [
+        record.message.messageId,
+        record.channelId,
+        record.serverId,
+        record.isDM ? 1 : 0,
+        record.mode,
+        record.directlyAddressed ? 1 : 0,
+        JSON.stringify(record.message),
+        now,
+        record.message.timestamp || now,
+        now,
+      ],
+    );
+  }
+
+  claim(messageIds: string[]): void {
+    const ids = uniqueIds(messageIds);
+    if (ids.length === 0) return;
+    const now = new Date().toISOString();
+    this.db.exec(
+      `UPDATE discord_pending_messages
+       SET state = 'processing', attempt_count = attempt_count + 1,
+           updated_at = ?
+       WHERE message_id IN (${placeholders(ids.length)})`,
+      [now, ...ids],
+    );
+  }
+
+  settle(messageIds: string[]): void {
+    const ids = uniqueIds(messageIds);
+    if (ids.length === 0) return;
+    this.db.exec(
+      `DELETE FROM discord_pending_messages
+       WHERE message_id IN (${placeholders(ids.length)})`,
+      ids,
+    );
+  }
+
+  release(messageIds: string[]): number {
+    const ids = uniqueIds(messageIds);
+    if (ids.length === 0) return BASE_RETRY_DELAY_MS;
+    const statement = this.db.prepare(
+      `SELECT COALESCE(MAX(attempt_count), 1) AS attempts
+       FROM discord_pending_messages
+       WHERE message_id IN (${placeholders(ids.length)})`,
+    );
+    const row = statement.get<{ attempts: number }>(...ids);
+    statement.finalize();
+    const attempts = Math.max(1, Number(row?.attempts ?? 1));
+    const delayMs = Math.min(
+      BASE_RETRY_DELAY_MS * (2 ** Math.min(attempts - 1, 5)),
+      MAX_RETRY_DELAY_MS,
+    );
+    const now = new Date();
+    const nextAttemptAt = new Date(now.getTime() + delayMs).toISOString();
+    this.db.exec(
+      `UPDATE discord_pending_messages
+       SET state = 'pending', next_attempt_at = ?, updated_at = ?
+       WHERE message_id IN (${placeholders(ids.length)})`,
+      [nextAttemptAt, now.toISOString(), ...ids],
+    );
+    return delayMs;
+  }
+
+  recoverReady(now = new Date()): PendingDiscordMessage[] {
+    const statement = this.db.prepare(
+      `SELECT message_id, channel_id, server_id, is_dm, channel_mode,
+              directly_addressed, message_json
+       FROM discord_pending_messages
+       WHERE state = 'pending' AND next_attempt_at <= ?
+       ORDER BY received_at ASC, message_id ASC
+       LIMIT ?`,
+    );
+    const rows = statement.all<PendingDiscordMessageRow>(
+      now.toISOString(),
+      MAX_RECOVERY_BATCH,
+    );
+    statement.finalize();
+
+    const recovered: PendingDiscordMessage[] = [];
+    for (const row of rows) {
+      try {
+        recovered.push({
+          channelId: row.channel_id,
+          serverId: row.server_id,
+          isDM: row.is_dm === 1,
+          mode: parseChannelMode(row.channel_mode),
+          directlyAddressed: row.directly_addressed === 1,
+          message: parseAccumulatedMessage(row.message_json),
+        });
+      } catch (error) {
+        console.warn(
+          `[Discord] Could not recover pending message ${row.message_id}:`,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+    return recovered;
+  }
+
+  count(): number {
+    const statement = this.db.prepare(
+      "SELECT COUNT(*) AS count FROM discord_pending_messages",
+    );
+    const row = statement.get<{ count: number }>();
+    statement.finalize();
+    return Number(row?.count ?? 0);
+  }
+
+  private reclaimProcessingOnStart(): void {
+    const now = new Date().toISOString();
+    this.db.exec(
+      `UPDATE discord_pending_messages
+       SET state = 'pending', next_attempt_at = ?, updated_at = ?
+       WHERE state = 'processing'`,
+      [now, now],
+    );
+  }
+}
+
+function uniqueIds(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+function placeholders(count: number): string {
+  return new Array(count).fill("?").join(", ");
+}
+
+function parseChannelMode(value: string): ChannelMode {
+  if (value === "active" || value === "lurk" || value === "strict") {
+    return value;
+  }
+  throw new Error(`invalid channel mode ${value}`);
+}
+
+function parseAccumulatedMessage(value: string): AccumulatedMessage {
+  const parsed = JSON.parse(value) as Partial<AccumulatedMessage>;
+  if (
+    typeof parsed.messageId !== "string" ||
+    typeof parsed.authorId !== "string" ||
+    typeof parsed.authorUsername !== "string" ||
+    typeof parsed.content !== "string" ||
+    typeof parsed.timestamp !== "string"
+  ) {
+    throw new Error("pending message payload is malformed");
+  }
+  return {
+    authorId: parsed.authorId,
+    authorUsername: parsed.authorUsername,
+    authorBot: parsed.authorBot === true,
+    content: parsed.content,
+    timestamp: parsed.timestamp,
+    messageId: parsed.messageId,
+    mentionsBot: parsed.mentionsBot === true,
+    replyToBot: parsed.replyToBot === true,
+    referenceMessageId: typeof parsed.referenceMessageId === "string"
+      ? parsed.referenceMessageId
+      : null,
+  };
+}

--- a/packages/psycheros/src/discord/router.ts
+++ b/packages/psycheros/src/discord/router.ts
@@ -13,6 +13,10 @@ import type {
   DiscordGatewayConfig,
 } from "../llm/discord-settings.ts";
 import type { ConversationMapper } from "./conversation-map.ts";
+import type {
+  DiscordPendingStore,
+  PendingDiscordMessage,
+} from "./pending-store.ts";
 
 // =============================================================================
 // Types
@@ -38,11 +42,21 @@ export interface RouterDeps {
     conversationId: string,
     userMessage: string,
     context: DiscordTurnContext,
-  ) => Promise<void>;
+  ) => Promise<DiscordTurnOutcome | void>;
   onMessage?: (
     channelId: string,
     message: AccumulatedMessage,
   ) => Promise<void> | void;
+  pendingStore?: DiscordPendingStore;
+}
+
+export type DiscordTurnDisposition =
+  | "contributed"
+  | "deliberately_quiet"
+  | "failed";
+
+export interface DiscordTurnOutcome {
+  disposition: DiscordTurnDisposition;
 }
 
 export interface DiscordTurnContext {
@@ -54,10 +68,19 @@ export interface DiscordTurnContext {
   isDM: boolean;
   senderUsername: string;
   senderUserId: string;
+  /** Messages in this bounded batch that replies and reactions may target. */
+  eligibleMessageIds: string[];
+  /** Commit durable receipt work after the first visible Discord action. */
+  commitVisibleAction?: () => void;
   /** In lurk mode, individual messages are already persisted — skip userMessage persistence in the turn */
   skipUserMessagePersist?: boolean;
   /** The active mode tier that triggered this turn (only set for active mode channels) */
   activeTier?: ActiveTier;
+}
+
+interface DeferredFlush {
+  mode: ChannelMode;
+  tier?: ActiveTier;
 }
 
 // =============================================================================
@@ -72,6 +95,8 @@ export class MessageRouter {
   private timers: Map<string, ReturnType<typeof setTimeout>> = new Map();
   /** Per-channel processing lock to prevent overlapping turns */
   private processing: Set<string> = new Set();
+  /** One coalesced eligible flush waiting behind the active channel turn. */
+  private deferredFlushes: Map<string, DeferredFlush> = new Map();
   /** Per-channel message timestamps for rate calculation (rolling window) */
   private messageTimestamps: Map<string, number[]> = new Map();
   /** Per-channel periodic digest timers (for medium/fast tiers) */
@@ -81,6 +106,8 @@ export class MessageRouter {
   private channelTiers: Map<string, ActiveTier> = new Map();
   /** Handle for the timestamp pruning interval */
   private pruneInterval: ReturnType<typeof setInterval> | null = null;
+  /** Failed or interrupted durable work retries without requiring a new post. */
+  private pendingRecoveryInterval: ReturnType<typeof setInterval> | null = null;
   /** DM channel IDs currently being tracked (not in server config) */
   private dmChannels: Set<string> = new Set();
 
@@ -110,6 +137,13 @@ export class MessageRouter {
         console.error("[Discord] prune timer error (non-fatal):", error);
       }
     }, 5 * 60 * 1000);
+    if (this.deps.pendingStore) {
+      queueMicrotask(() => this.recoverPendingMessages());
+      this.pendingRecoveryInterval = setInterval(
+        () => this.recoverPendingMessages(),
+        30_000,
+      );
+    }
     console.log("[Discord] Message router started");
   }
 
@@ -126,8 +160,13 @@ export class MessageRouter {
       clearInterval(this.pruneInterval);
       this.pruneInterval = null;
     }
+    if (this.pendingRecoveryInterval) {
+      clearInterval(this.pendingRecoveryInterval);
+      this.pendingRecoveryInterval = null;
+    }
     this.buffers.clear();
     this.processing.clear();
+    this.deferredFlushes.clear();
     this.messageTimestamps.clear();
     this.channelTiers.clear();
     this.dmChannels.clear();
@@ -158,7 +197,10 @@ export class MessageRouter {
           clearTimeout(debounce);
           this.timers.delete(channelId);
         }
+        const discarded = this.buffers.get(channelId) ?? [];
         this.buffers.delete(channelId);
+        this.settlePending(discarded.map((message) => message.messageId));
+        this.deferredFlushes.delete(channelId);
         this.channelTiers.delete(channelId);
         this.messageTimestamps.delete(channelId);
         console.log(
@@ -229,6 +271,14 @@ export class MessageRouter {
       replyToBot,
       referenceMessageId: msg.reference?.message_id ?? null,
     };
+    this.persistPending({
+      channelId,
+      serverId,
+      isDM: false,
+      mode,
+      directlyAddressed: mentionsBot || replyToBot || isEveryoneHere,
+      message: accumulated,
+    });
 
     this.addToBuffer(
       channelId,
@@ -251,19 +301,28 @@ export class MessageRouter {
     // doesn't silently drop it (DM channels are never in server config).
     this.dmChannels.add(msg.channel_id);
 
+    const accumulated: AccumulatedMessage = {
+      authorId: msg.author.id,
+      authorUsername: msg.author.global_name || msg.author.username,
+      authorBot: false,
+      content: msg.content,
+      timestamp: msg.timestamp,
+      messageId: msg.id,
+      mentionsBot: true, // DMs always trigger
+      replyToBot: false,
+      referenceMessageId: msg.reference?.message_id ?? null,
+    };
+    this.persistPending({
+      channelId: msg.channel_id,
+      serverId: null,
+      isDM: true,
+      mode: "active",
+      directlyAddressed: true,
+      message: accumulated,
+    });
     this.addToBuffer(
       msg.channel_id,
-      {
-        authorId: msg.author.id,
-        authorUsername: msg.author.global_name || msg.author.username,
-        authorBot: false,
-        content: msg.content,
-        timestamp: msg.timestamp,
-        messageId: msg.id,
-        mentionsBot: true, // DMs always trigger
-        replyToBot: false,
-        referenceMessageId: msg.reference?.message_id ?? null,
-      },
+      accumulated,
       "active",
       true,
     );
@@ -292,7 +351,9 @@ export class MessageRouter {
     // Cap buffer size
     const maxSize = this.deps.config.maxBufferSize;
     if (buffer.length > maxSize) {
+      const discarded = buffer.slice(0, buffer.length - maxSize);
       buffer = buffer.slice(-maxSize);
+      this.settlePending(discarded.map((item) => item.messageId));
     }
 
     this.buffers.set(channelId, buffer);
@@ -409,7 +470,10 @@ export class MessageRouter {
       !this.getChannelConfigByChannelId(channelId)
     ) {
       this.clearPeriodicTimer(channelId);
+      const discarded = this.buffers.get(channelId) ?? [];
       this.buffers.delete(channelId);
+      this.settlePending(discarded.map((message) => message.messageId));
+      this.deferredFlushes.delete(channelId);
       return;
     }
 
@@ -448,8 +512,9 @@ export class MessageRouter {
 
     // Prevent overlapping turns per channel
     if (this.processing.has(channelId)) {
+      this.deferredFlushes.set(channelId, { mode, tier });
       console.log(
-        `[Discord] Channel ${channelId} already processing, skipping`,
+        `[Discord] Channel ${channelId} already processing; flush deferred`,
       );
       return;
     }
@@ -459,6 +524,16 @@ export class MessageRouter {
     this.buffers.delete(channelId);
 
     this.processing.add(channelId);
+    const messageIds = [...new Set(buffer.map((message) => message.messageId))];
+    try {
+      this.deps.pendingStore?.claim(messageIds);
+    } catch (error) {
+      console.warn(
+        `[Discord] Could not claim durable batch for ${channelId}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    let durableWorkCommitted = false;
     try {
       // Build conversation ID and user message
       const isDM = !buffer[0]?.replyToBot &&
@@ -493,18 +568,124 @@ export class MessageRouter {
         isDM,
         senderUsername: triggerMsg.authorUsername,
         senderUserId: triggerMsg.authorId,
+        eligibleMessageIds: messageIds,
+        commitVisibleAction: () => {
+          if (durableWorkCommitted) return;
+          this.settlePending(messageIds);
+          durableWorkCommitted = true;
+        },
         skipUserMessagePersist: false,
         activeTier: tier,
       };
 
-      await this.deps.onTurn(conversationId, userMessage, context);
+      const outcome = await this.deps.onTurn(
+        conversationId,
+        userMessage,
+        context,
+      );
+      if (outcome?.disposition === "failed") {
+        if (!durableWorkCommitted) this.releasePending(messageIds);
+      } else {
+        this.settlePending(messageIds);
+        durableWorkCommitted = true;
+      }
     } catch (error) {
+      if (!durableWorkCommitted) this.releasePending(messageIds);
       console.error(
         `[Discord] Error processing turn for channel ${channelId}:`,
         error,
       );
     } finally {
       this.processing.delete(channelId);
+      const deferred = this.deferredFlushes.get(channelId);
+      this.deferredFlushes.delete(channelId);
+      if (deferred && (this.buffers.get(channelId)?.length ?? 0) > 0) {
+        queueMicrotask(() => {
+          void this.flushBuffer(channelId, deferred.mode, deferred.tier);
+        });
+      }
+    }
+  }
+
+  private persistPending(record: PendingDiscordMessage): void {
+    try {
+      this.deps.pendingStore?.enqueue(record);
+    } catch (error) {
+      console.warn(
+        `[Discord] Could not persist pending message ${record.message.messageId}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private settlePending(messageIds: string[]): void {
+    try {
+      this.deps.pendingStore?.settle(messageIds);
+    } catch (error) {
+      console.warn(
+        "[Discord] Could not settle durable pending work:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private releasePending(messageIds: string[]): void {
+    try {
+      this.deps.pendingStore?.release(messageIds);
+    } catch (error) {
+      console.warn(
+        "[Discord] Could not release durable pending work:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private recoverPendingMessages(): void {
+    const store = this.deps.pendingStore;
+    if (!store) return;
+    let recovered: PendingDiscordMessage[];
+    try {
+      recovered = store.recoverReady();
+    } catch (error) {
+      console.warn(
+        "[Discord] Pending-message recovery failed:",
+        error instanceof Error ? error.message : String(error),
+      );
+      return;
+    }
+
+    let added = 0;
+    for (const record of recovered) {
+      try {
+        if (
+          !record.isDM &&
+          (!record.serverId ||
+            !this.getChannelConfig(record.serverId, record.channelId))
+        ) {
+          this.settlePending([record.message.messageId]);
+          continue;
+        }
+        const alreadyBuffered = this.buffers.get(record.channelId)?.some(
+          (message) => message.messageId === record.message.messageId,
+        ) === true;
+        if (alreadyBuffered) continue;
+        if (record.isDM) this.dmChannels.add(record.channelId);
+        this.addToBuffer(
+          record.channelId,
+          record.message,
+          record.mode,
+          record.directlyAddressed,
+        );
+        added++;
+      } catch (error) {
+        console.warn(
+          `[Discord] Could not restore pending message ${record.message.messageId}:`,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+    if (added > 0) {
+      console.log(`[Discord] Recovered ${added} durable pending message(s)`);
     }
   }
 
@@ -591,13 +772,15 @@ export class MessageRouter {
       !this.getChannelConfigByChannelId(channelId)
     ) {
       this.clearPeriodicTimer(channelId);
+      const discarded = this.buffers.get(channelId) ?? [];
       this.buffers.delete(channelId);
+      this.settlePending(discarded.map((message) => message.messageId));
+      this.deferredFlushes.delete(channelId);
       return;
     }
 
     const buffer = this.buffers.get(channelId);
     if (!buffer || buffer.length === 0) return;
-    if (this.processing.has(channelId)) return;
 
     // Recalculate tier — channel activity may have changed
     const newTier = this.calculateTier(channelId);

--- a/packages/psycheros/src/entity/loop.ts
+++ b/packages/psycheros/src/entity/loop.ts
@@ -247,6 +247,8 @@ export interface ProcessOptions {
     isDM: boolean;
     senderUsername: string;
     senderUserId: string;
+    eligibleMessageIds: string[];
+    commitVisibleAction?: () => void;
     activeTier?: import("../llm/discord-settings.ts").ActiveTier;
   };
   /**
@@ -870,6 +872,14 @@ export class EntityTurn {
           `\nMy instructions for Discord:\n${this.config.discordSettings.globalInstructions}`,
         );
       }
+
+      parts.push(
+        `\nThe message IDs I may target in this turn are: ${
+          ctx.eligibleMessageIds.length > 0
+            ? ctx.eligibleMessageIds.join(", ")
+            : "none"
+        }. Older Discord messages visible in conversation history are context, not unanswered requests. If I do not act on the current batch, quiet is a complete decision and future ordinary turns should not reopen it.`,
+      );
       // Add per-channel instructions if present
       if (this.config.discordGatewayConfig) {
         for (const server of this.config.discordGatewayConfig.servers) {
@@ -915,7 +925,8 @@ Discord interaction:
 - To reply to a specific message, I include 'content' and 'message_id' — my message threads under it. To send a plain channel message, I omit 'message_id'.
 - To react to a message, I include 'emoji' (one or more emoji, e.g. 👍 or ["🔥","💀"]) and 'message_id'.
 - I can combine reply and react in one action: { message_id, content, emoji } replies to and reacts to the same message.
-- If I have nothing to add, I simply don't call the tool. No message is sent. This is a natural pass.
+- I do not reply merely to agree, restate another speaker, prove presence, or answer every line in a busy room. A fitting reaction or quiet may be the complete contribution.
+- If I have nothing to add, I simply don't call the tool. No message is sent, and this current batch is settled.
 - I reserve @mentions (<@userId>) for when I genuinely need to draw someone's attention. Using @mentions for every reply is redundant when message threading already makes the connection clear.`);
       discordChannelContent = parts.join("\n");
     }

--- a/packages/psycheros/src/entity/token-budget.ts
+++ b/packages/psycheros/src/entity/token-budget.ts
@@ -150,6 +150,17 @@ function sanitizeMessageSequence(messages: ChatMessage[]): ChatMessage[] {
     const prev = result[result.length - 1];
     const prevRole = prev.role;
 
+    // Intentional no-message turns (for example a deliberate Discord pass)
+    // can leave consecutive user rows in durable history. The last message is
+    // the current user input and is the one invariant this sanitizer must not
+    // violate. Replace an older adjacent user row with the newer one instead
+    // of keeping the stale row and dropping the current turn.
+    if (prevRole === "user" && msg.role === "user") {
+      result[result.length - 1] = msg;
+      prevHadToolCalls = false;
+      continue;
+    }
+
     let valid = false;
 
     switch (prevRole) {

--- a/packages/psycheros/src/server/server.ts
+++ b/packages/psycheros/src/server/server.ts
@@ -84,8 +84,11 @@ import { PulseEngine } from "../pulse/mod.ts";
 import { setPulseEngine } from "../tools/pulse-tools.ts";
 import { DeviceStatusCache } from "./device-cache.ts";
 import {
+  classifyDiscordTurnDisposition,
   ConversationMapper,
   DiscordGatewayClient,
+  DiscordPendingStore,
+  type DiscordTurnOutcome,
   MessageRouter,
   ResponseHandler,
 } from "../discord/mod.ts";
@@ -897,6 +900,7 @@ export class Server {
         gateway: this.discordGatewayClient,
         config: this.discordGatewayConfig,
         conversationMapper: this.discordConversationMapper,
+        pendingStore: new DiscordPendingStore(this.db.getRawDb()),
         onTurn: (conversationId, userMessage, context) =>
           this.handleDiscordTurn(conversationId, userMessage, context),
         onMessage: (channelId, message) =>
@@ -1015,8 +1019,15 @@ export class Server {
     conversationId: string,
     userMessage: string,
     context: import("../discord/router.ts").DiscordTurnContext,
-  ): Promise<void> {
-    if (!this.discordResponseHandler) return;
+  ): Promise<DiscordTurnOutcome> {
+    if (!this.discordResponseHandler) return { disposition: "failed" };
+
+    let discordActionSucceeded = false;
+    const commitVisibleAction = context.commitVisibleAction;
+    context.commitVisibleAction = () => {
+      discordActionSucceeded = true;
+      commitVisibleAction?.();
+    };
 
     // Show typing indicator
     await this.discordResponseHandler.triggerTyping(context.channelId);
@@ -1081,27 +1092,43 @@ export class Server {
         `[System Message: The following messages are piped in from a connected Discord channel (${location}). Each message shows the author, mention ID, timestamp, and message ID.${identity}]\n\n`;
       const contextualizedMessage = header + userMessage;
 
+      let discordActionAttempted = false;
       for await (
-        const _ of turn.process(conversationId, contextualizedMessage, {
+        const chunk of turn.process(conversationId, contextualizedMessage, {
           sourceType: "discord",
           discordContext: context,
           skipStickyDecrement: true,
           skipUserPersist: context.skipUserMessagePersist,
         })
       ) {
-        // Consume the generator — tool calls within the loop handle Discord output
+        if (
+          chunk.type === "tool_call" &&
+          chunk.toolCall.function.name === "act_in_discord"
+        ) {
+          discordActionAttempted = true;
+        }
       }
+      const disposition = classifyDiscordTurnDisposition({
+        discordActionAttempted,
+        discordActionSucceeded,
+      });
+      if (disposition === "deliberately_quiet") {
+        console.log(
+          `[Discord] Channel ${context.channelId}: deliberate pass`,
+        );
+      }
+      if (context.activeTier) {
+        console.log(
+          `[Discord] Channel ${context.channelId}: entity turn completed (tier: ${context.activeTier})`,
+        );
+      }
+      return { disposition };
     } catch (error) {
       console.error(
         "[Discord] Entity turn error:",
         error instanceof Error ? error.message : String(error),
       );
-    }
-
-    if (context.activeTier) {
-      console.log(
-        `[Discord] Channel ${context.channelId}: entity turn completed (tier: ${context.activeTier})`,
-      );
+      return { disposition: "failed" };
     }
   }
 

--- a/packages/psycheros/src/tools/discord-action.ts
+++ b/packages/psycheros/src/tools/discord-action.ts
@@ -24,7 +24,7 @@ export const actInDiscordTool: Tool = {
     function: {
       name: "act_in_discord",
       description:
-        "I use this tool to act in the current Discord channel. I pass an 'actions' array — I should batch everything I want to do into a single call (reply to multiple messages, react to several, or mix both). Each action can include 'content' (to send a message), 'emoji' (to react, one or more), or both on the same 'message_id'. If I have nothing to add, I simply don't call this tool — no message will be sent.",
+        "I use this tool to act in the current Discord channel. I pass one batched 'actions' array. A message_id must belong to the current bounded batch; older conversation history is context, not an open request. If I have nothing to add, I simply don't call this tool.",
       parameters: {
         type: "object",
         properties: {
@@ -38,7 +38,7 @@ export const actInDiscordTool: Tool = {
                 message_id: {
                   type: "string",
                   description:
-                    "The Discord message ID to target. If I include 'content', my reply threads under this message. If I include 'emoji', I react to this message. Omit to send a plain channel message (no threading).",
+                    "A message ID from the current bounded Discord batch. If I include 'content', my reply threads under it; if I include 'emoji', I react to it. Omit to send a plain channel message.",
                 },
                 content: {
                   type: "string",
@@ -99,6 +99,23 @@ export const actInDiscordTool: Tool = {
       };
     }
 
+    for (const action of actions) {
+      const messageId = typeof action.message_id === "string" &&
+          action.message_id.trim()
+        ? action.message_id.trim()
+        : undefined;
+      if (
+        messageId && !isDiscordActionTargetEligible(discordContext, messageId)
+      ) {
+        return {
+          toolCallId: ctx.toolCallId,
+          content:
+            `Message ${messageId} is historical context, not an eligible target for this turn. I can target only the current Discord batch.`,
+          isError: true,
+        };
+      }
+    }
+
     const channelId = discordContext.channelId;
     const headers = {
       "Authorization": `Bot ${discordSettings.botToken}`,
@@ -107,6 +124,7 @@ export const actInDiscordTool: Tool = {
 
     const results: string[] = [];
     let hadError = false;
+    let hadVisibleSuccess = false;
 
     for (const action of actions) {
       const hasContent = typeof action.content === "string" &&
@@ -130,6 +148,10 @@ export const actInDiscordTool: Tool = {
         const result = await executeReply(action, channelId, headers);
         results.push(result.content);
         if (result.isError) hadError = true;
+        else {
+          hadVisibleSuccess = true;
+          discordContext.commitVisibleAction?.();
+        }
       }
 
       // Add reactions if emoji is present
@@ -149,6 +171,10 @@ export const actInDiscordTool: Tool = {
             );
             results.push(result.content);
             if (result.isError) hadError = true;
+            else {
+              hadVisibleSuccess = true;
+              discordContext.commitVisibleAction?.();
+            }
           }
         }
       }
@@ -157,10 +183,17 @@ export const actInDiscordTool: Tool = {
     return {
       toolCallId: ctx.toolCallId,
       content: results.join("\n"),
-      isError: hadError,
+      isError: hadError && !hadVisibleSuccess,
     };
   },
 };
+
+export function isDiscordActionTargetEligible(
+  context: { eligibleMessageIds?: string[] },
+  messageId: string,
+): boolean {
+  return context.eligibleMessageIds?.includes(messageId) === true;
+}
 
 /**
  * Normalize the emoji field — accept a string or array of strings.

--- a/packages/psycheros/tests/discord_continuity_test.ts
+++ b/packages/psycheros/tests/discord_continuity_test.ts
@@ -1,0 +1,296 @@
+import { Database } from "@db/sqlite";
+import { assertEquals } from "@std/assert";
+import { initializeSchema } from "../src/db/schema.ts";
+import type { DBClient } from "../src/db/client.ts";
+import type { EntityConfig } from "../src/entity/loop.ts";
+import {
+  classifyDiscordTurnDisposition,
+  DiscordPendingStore,
+  MessageRouter,
+} from "../src/discord/mod.ts";
+import type {
+  AccumulatedMessage,
+  DiscordTurnContext,
+} from "../src/discord/router.ts";
+import type {
+  DiscordGatewayClient,
+  DiscordMessage,
+  GatewayEventHandler,
+  GatewayEventType,
+} from "../src/discord/gateway.ts";
+import type { ConversationMapper } from "../src/discord/conversation-map.ts";
+import {
+  actInDiscordTool,
+  isDiscordActionTargetEligible,
+} from "../src/tools/discord-action.ts";
+import { getDefaultDiscordGatewayConfig } from "../src/llm/discord-settings.ts";
+
+function message(id = "message-1"): AccumulatedMessage {
+  return {
+    authorId: "user-1",
+    authorUsername: "Test User",
+    authorBot: false,
+    content: "<@bot-1> this should survive a restart",
+    timestamp: "2026-07-28T16:00:00.000Z",
+    messageId: id,
+    mentionsBot: true,
+    replyToBot: false,
+    referenceMessageId: null,
+  };
+}
+
+function gatewayStub(
+  handlers?: Map<GatewayEventType, GatewayEventHandler[]>,
+): DiscordGatewayClient {
+  return {
+    on: (event: GatewayEventType, handler: GatewayEventHandler) => {
+      const existing = handlers?.get(event) ?? [];
+      existing.push(handler);
+      handlers?.set(event, existing);
+    },
+    getBotUserId: () => "bot-1",
+    getChannels: () =>
+      new Map([["channel-1", { id: "channel-1", name: "general" }]]),
+  } as unknown as DiscordGatewayClient;
+}
+
+function mapperStub(): ConversationMapper {
+  return {
+    getOrCreateConversation: () => Promise.resolve("conversation-1"),
+  } as unknown as ConversationMapper;
+}
+
+function strictConfig() {
+  const config = getDefaultDiscordGatewayConfig();
+  config.servers = [{
+    serverId: "server-1",
+    serverName: "Test",
+    channels: [{
+      channelId: "channel-1",
+      mode: "strict",
+      instructions: "",
+    }],
+  }];
+  return config;
+}
+
+Deno.test("Discord durable inbox reclaims processing rows and settles deliberate quiet", async () => {
+  const db = new Database(":memory:");
+  initializeSchema(db);
+  const firstStore = new DiscordPendingStore(db);
+  firstStore.enqueue({
+    channelId: "channel-1",
+    serverId: "server-1",
+    isDM: false,
+    mode: "strict",
+    directlyAddressed: true,
+    message: message(),
+  });
+  firstStore.claim(["message-1"]);
+  assertEquals(firstStore.recoverReady().length, 0);
+
+  const restartedStore = new DiscordPendingStore(db);
+  assertEquals(restartedStore.recoverReady().length, 1);
+  let seenContext: DiscordTurnContext | undefined;
+  const router = new MessageRouter({
+    gateway: gatewayStub(),
+    pendingStore: restartedStore,
+    conversationMapper: mapperStub(),
+    config: strictConfig(),
+    onTurn: async (_conversationId, _userMessage, context) => {
+      seenContext = context;
+      return { disposition: "deliberately_quiet" };
+    },
+  });
+  router.start();
+
+  const deadline = Date.now() + 1_000;
+  while (restartedStore.count() > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  router.stop();
+
+  assertEquals(restartedStore.count(), 0);
+  assertEquals(seenContext?.eligibleMessageIds, ["message-1"]);
+  db.close();
+});
+
+Deno.test("Discord failed turn remains durable and retryable", async () => {
+  const db = new Database(":memory:");
+  initializeSchema(db);
+  const store = new DiscordPendingStore(db);
+  store.enqueue({
+    channelId: "channel-1",
+    serverId: "server-1",
+    isDM: false,
+    mode: "strict",
+    directlyAddressed: true,
+    message: message(),
+  });
+  let attempted = false;
+  const router = new MessageRouter({
+    gateway: gatewayStub(),
+    pendingStore: store,
+    conversationMapper: mapperStub(),
+    config: strictConfig(),
+    onTurn: () => {
+      attempted = true;
+      return Promise.resolve({ disposition: "failed" });
+    },
+  });
+  router.start();
+  const deadline = Date.now() + 1_000;
+  while (!attempted && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  router.stop();
+
+  assertEquals(store.count(), 1);
+  assertEquals(
+    store.recoverReady(new Date(Date.now() + 31_000)).map((record) =>
+      record.message.messageId
+    ),
+    ["message-1"],
+  );
+  db.close();
+});
+
+Deno.test("Discord overlapping eligible flush is deferred and runs after the active turn", async () => {
+  const handlers = new Map<GatewayEventType, GatewayEventHandler[]>();
+  let releaseFirst!: () => void;
+  const firstBlocked = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const turns: string[][] = [];
+  const router = new MessageRouter({
+    gateway: gatewayStub(handlers),
+    conversationMapper: mapperStub(),
+    config: strictConfig(),
+    onTurn: async (_conversationId, _userMessage, context) => {
+      turns.push(context.eligibleMessageIds);
+      if (turns.length === 1) await firstBlocked;
+      return { disposition: "deliberately_quiet" };
+    },
+  });
+  router.start();
+  const receive = handlers.get("MESSAGE_CREATE")?.[0];
+  if (!receive) throw new Error("MESSAGE_CREATE handler was not registered");
+
+  receive("MESSAGE_CREATE", discordMessage("message-1"));
+  const firstDeadline = Date.now() + 1_000;
+  while (turns.length < 1 && Date.now() < firstDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  receive("MESSAGE_CREATE", discordMessage("message-2"));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  releaseFirst();
+
+  const secondDeadline = Date.now() + 1_000;
+  while (turns.length < 2 && Date.now() < secondDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  router.stop();
+
+  assertEquals(turns, [["message-1"], ["message-2"]]);
+});
+
+Deno.test("Discord action rejects historical targets and commits visible work", async () => {
+  assertEquals(
+    isDiscordActionTargetEligible(
+      { eligibleMessageIds: ["current-message"] },
+      "old-message",
+    ),
+    false,
+  );
+  const originalFetch = globalThis.fetch;
+  let fetchCount = 0;
+  let commitCount = 0;
+  globalThis.fetch = (() => {
+    fetchCount++;
+    return Promise.resolve(
+      new Response(JSON.stringify({ id: "sent-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+  try {
+    const config = {
+      projectRoot: ".",
+      dataRoot: ".",
+      discordSettings: { botToken: "fake-token" },
+      discordContext: {
+        channelId: "channel-1",
+        channelName: "general",
+        serverId: "server-1",
+        serverName: "Test",
+        channelMode: "active",
+        isDM: false,
+        senderUsername: "Test User",
+        senderUserId: "user-1",
+        eligibleMessageIds: ["current-message"],
+        commitVisibleAction: () => commitCount++,
+      },
+    } as unknown as EntityConfig;
+    const db = {} as DBClient;
+    const rejected = await actInDiscordTool.execute({
+      actions: [{ message_id: "old-message", content: "Too late." }],
+    }, { toolCallId: "tool-1", conversationId: "conv-1", db, config });
+    assertEquals(rejected.isError, true);
+    assertEquals(fetchCount, 0);
+    assertEquals(commitCount, 0);
+
+    const sent = await actInDiscordTool.execute({
+      actions: [{
+        message_id: "current-message",
+        content: "This belongs to the current batch.",
+      }],
+    }, { toolCallId: "tool-2", conversationId: "conv-1", db, config });
+    assertEquals(sent.isError, false);
+    assertEquals(fetchCount, 1);
+    assertEquals(commitCount, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("Discord disposition separates quiet from failed visible action", () => {
+  assertEquals(
+    classifyDiscordTurnDisposition({
+      discordActionAttempted: false,
+      discordActionSucceeded: false,
+    }),
+    "deliberately_quiet",
+  );
+  assertEquals(
+    classifyDiscordTurnDisposition({
+      discordActionAttempted: true,
+      discordActionSucceeded: false,
+    }),
+    "failed",
+  );
+});
+
+function discordMessage(id: string): DiscordMessage {
+  return {
+    id,
+    channel_id: "channel-1",
+    guild_id: "server-1",
+    author: {
+      id: "user-1",
+      username: "tester",
+      global_name: "Test User",
+      bot: false,
+    },
+    content: `<@bot-1> ${id}`,
+    timestamp: new Date().toISOString(),
+    mentions: [{
+      id: "bot-1",
+      username: "test-bot",
+      global_name: "Test Bot",
+      bot: true,
+    }],
+    mention_everyone: false,
+  } as DiscordMessage;
+}

--- a/packages/psycheros/tests/token_budget_test.ts
+++ b/packages/psycheros/tests/token_budget_test.ts
@@ -68,6 +68,52 @@ Deno.test("token budget: all reasoning retained when budget fits", () => {
   assertEquals(kept.reasoning_content, pad(700));
 });
 
+Deno.test(
+  "token budget: consecutive user rows preserve the current user input",
+  () => {
+    const messages: ChatMessage[] = [
+      system(),
+      user("already handled by an intentional pass"),
+      user("current Discord batch"),
+    ];
+
+    const result = applyContextBudget(messages, NO_TOOLS, 100000, 1000);
+
+    assertEquals(result.messages.length, 2);
+    assertEquals(result.messages[0].role, "system");
+    assertEquals(result.messages[1].role, "user");
+    assertEquals(result.messages[1].content, "current Discord batch");
+    assertEquals(result.messagesRemoved, 1);
+  },
+);
+
+Deno.test(
+  "token budget: consecutive pass rows do not disturb earlier completed turns",
+  () => {
+    const messages: ChatMessage[] = [
+      system(),
+      user("earlier question"),
+      assistant("earlier answer"),
+      user("handled pass one"),
+      user("handled pass two"),
+      user("current batch"),
+    ];
+
+    const result = applyContextBudget(messages, NO_TOOLS, 100000, 1000);
+
+    assertEquals(
+      result.messages.map((message) => [message.role, message.content]),
+      [
+        ["system", "system"],
+        ["user", "earlier question"],
+        ["assistant", "earlier answer"],
+        ["user", "current batch"],
+      ],
+    );
+    assertEquals(result.messagesRemoved, 2);
+  },
+);
+
 // =============================================================================
 // Two-pass trim — single message stripped, message retained
 // =============================================================================


### PR DESCRIPTION
## Summary

- persist eligible Discord receipt work in Psycheros' existing local SQLite database until the entity reaches an explicit outcome
- distinguish visible contribution, deliberate quiet, and retryable failure
- coalesce an eligible flush that arrives while the channel already has a turn in flight
- prevent replies and reactions from reaching backward to message IDs that appear only in conversation history
- preserve the newest user batch when intentional no-message passes leave adjacent user rows
- tune the default Discord prompt toward restraint without turning silence into a failure

## Portable boundary

This intentionally uses only upstream Psycheros primitives. It does not depend on downstream Reflection, Experience, encounter-session, social-memory, or peer send-lease features. The schema and code use Deno/SQLite APIs already present in the project and contain no host-specific paths or commands.

## Verification

- `deno lint -- <touched TypeScript files>`
- `git diff --check`
- `deno test -A packages/psycheros/tests/` — 159 passed, 0 failed
- focused token-budget coverage: 9 passed, 0 failed
- focused continuity coverage: restart reclaim, deliberate quiet settlement, retryable failure, overlapping-flush continuation, current-batch target validation, and visible-action disposition

The broader monorepo command reached 186 passing tests, but eight existing `packages/entity-core/tests/runner_test.ts` cases failed during Windows temp-directory cleanup with `os error 32` (SQLite files still held while `Deno.remove(..., { recursive: true })` ran). This branch does not touch Entity Core or those tests.

Closes #38
Closes #49